### PR TITLE
README.md: Add --force to rustup install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ book](https://doc.rust-lang.org/book/2018-edition/ch01-01-installation.html)).
 
 2. Next, switch your version of `rustc` to the one that works with mir-json.
 
-       $ rustup toolchain install nightly-2019-08-05
+       $ rustup toolchain install nightly-2019-08-05 --force
        $ rustup default nightly-2019-08-05
 
 3. Now compile `mir-json` and install its executables to your path.


### PR DESCRIPTION
On recent versions of rustup, it attempts to auto-install clippy, which isn't available for that particular nightly:

```
$ rustup toolchain install nightly-2019-08-05                                                                                                                                                                                                         
info: syncing channel updates for 'nightly-2019-08-05-x86_64-apple-darwin'
info: latest update on 2019-08-05, rust version 1.38.0-nightly (d3f8a0b5d 2019-08-04)
error: component 'clippy' for target 'x86_64-apple-darwin' is unavailable for download for channel nightly-2019-08-05
```

Adding `--force` causes it to skip clippy:

```
$ rustup toolchain install nightly-2019-08-05 --force
info: syncing channel updates for 'nightly-2019-08-05-x86_64-apple-darwin'
info: latest update on 2019-08-05, rust version 1.38.0-nightly (d3f8a0b5d 2019-08-04)
warning: Force-skipping unavailable component 'clippy-x86_64-apple-darwin'
info: downloading component 'cargo'
info: downloading component 'rust-docs'
[...]
```