### PR TITLE
pass test file to crux-mir via --cargo-test-file

### DIFF
--- a/src/bin/mir-json-rustc-wrapper.rs
+++ b/src/bin/mir-json-rustc-wrapper.rs
@@ -126,7 +126,7 @@ fn write_test_script(script_path: &Path, json_path: &Path) -> io::Result<()> {
     let mut f = OpenOptions::new().write(true).create(true).truncate(true)
         .mode(0o755).open(script_path)?;
     writeln!(f, "#!/bin/sh")?;
-    writeln!(f, r#"exec crux-mir --assert-false-on-error "$(dirname "$0")"/'{}' "$@""#, json_name)?;
+    writeln!(f, r#"exec crux-mir --assert-false-on-error --cargo-test-file "$(dirname "$0")"/'{}' "$@""#, json_name)?;
     Ok(())
 }
 


### PR DESCRIPTION
This enables `crux-mir`'s new support for test filtering: `cargo crux-test foo` will run only those tests that have `foo` in the name.  See GaloisInc/mir-verifier#15 for details.