### PR TITLE
allow changing crux-mir binary path using CRUX_MIR env var

### DIFF
--- a/src/bin/mir-json-rustc-wrapper.rs
+++ b/src/bin/mir-json-rustc-wrapper.rs
@@ -155,7 +155,7 @@ fn write_test_script(script_path: &Path, json_path: &Path) -> io::Result<()> {
     let mut f = OpenOptions::new().write(true).create(true).truncate(true)
         .mode(0o755).open(script_path)?;
     writeln!(f, "#!/bin/sh")?;
-    writeln!(f, r#"exec crux-mir --assert-false-on-error --cargo-test-file "$(dirname "$0")"/'{}' "$@""#, json_name)?;
+    writeln!(f, r#"exec "${{CRUX_MIR:-crux-mir}}" --assert-false-on-error --cargo-test-file "$(dirname "$0")"/'{}' "$@""#, json_name)?;
     Ok(())
 }
 


### PR DESCRIPTION
This branch changes the test-runner script generated by `cargo crux-test` to invoke `$CRUX_MIR` (if that variable is set) instead of always invoking `crux-mir`.  This makes it easier to use `cargo crux-test` with `crux-mir-comp` - previously, you had to manually symlink `crux-mir` to `crux-mir-comp`, but now you can simply `export CRUX_MIR=crux-mir-comp` instead.