### PR TITLE
Allow custom target for `cargo saw-build` and `crux-test`

### DIFF
--- a/src/bin/cargo_test_common.rs
+++ b/src/bin/cargo_test_common.rs
@@ -151,8 +151,10 @@ pub fn cargo_test_common(subcmd_name: &'static str, subcmd_descr: &'static str,
     args.push("test".into());
     // XXX big hack.  See `mir-json-rustc-wrapper.rs` for an explanation of why we set `--target`
     // explicitly to its default value.
-    args.push("--target".into());
-    args.push(host_triple().into());
+    if !orig_args.iter().any(|a| a == "--target") {
+        args.push("--target".into());
+        args.push(host_triple().into());
+    }
     for extra_arg in extra_args {
         args.push(extra_arg.into());
     }


### PR DESCRIPTION
Due to the [big hack](https://github.com/GaloisInc/mir-json/blob/ec2cbf6d9a1d435f25da813a467cea533e8e7a46/src/bin/mir-json-rustc-wrapper.rs#L163-L169) we explicitly pass the `--target` flag to the rustc wrapper in `cargo_test_common`. However if the user already explicitly passes `--target` for cross compiling, then we end up passing two `--target`s to cargo, which makes it compile for both targets. Therefore we should only pass `--target <host_triple>` if there is no existing `--target`. Similar logic already exists in [`saw-rustc`](https://github.com/GaloisInc/mir-json/blob/ec2cbf6d9a1d435f25da813a467cea533e8e7a46/src/bin/saw-rustc.rs#L20-L26) and [`crux-rustc`](https://github.com/GaloisInc/mir-json/blob/ec2cbf6d9a1d435f25da813a467cea533e8e7a46/src/bin/crux-rustc.rs#L19-L25).