### PR TITLE
Explicitly version the JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,20 @@ book](https://doc.rust-lang.org/book/2018-edition/ch01-01-installation.html)).
 
 See the [crux-mir][crux-mir-repo] README for usage instructions.
 
+## JSON schema
+
+`mir-json` and related tools produce MIR JSON files as output, which the
+contain the intermediate MIR code from the compiled program in a
+machine-readable format. Downstream tools are sensitive to the particular
+schema that a MIR JSON file uses, so we explicitly record the version of the
+JSON schema in each MIR JSON file (in the `"version"` field).
+
+Any time that `mir-json` is updated such that the JSON schema must also be
+changed, we will also update the schema version number. The version number is
+represented as a single integer. Any changes to the schema are assumed to be
+backwards-incompatible with previous versions of the schema, so all version
+bumps should be treated as major version bumps. Each change to the schema is
+described in the [`SCHEMA_VERSIONING.md`](SCHEMA_VERSIONING.md) file.
+
 
 [crux-mir-repo]: https://github.com/GaloisInc/crucible/tree/master/crux-mir

--- a/SCHEMA_CHANGELOG.md
+++ b/SCHEMA_CHANGELOG.md
@@ -1,0 +1,8 @@
+The following document describes the changes to the JSON schema that
+`mir-json`–produced files adhere to. (This document should not be interpreted
+as a changelog for the code in the `mir-json` tools themselves, which are
+versioned separately.)
+
+## 1
+
+Initial schema version.

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -32,6 +32,7 @@ mod ty_json;
 use analyz::to_json::*;
 use analyz::ty_json::*;
 use lib_util::{self, JsonOutput, EntryKind};
+use schema_ver::SCHEMA_VER;
 
 basic_json_enum_impl!(mir::BinOp);
 
@@ -1168,6 +1169,7 @@ pub fn analyze_nonstreaming<'tcx>(
     let total_items = out.fns.len() + out.adts.len() + out.statics.len() + out.vtables.len() +
         out.traits.len() + out.intrinsics.len();
     let j = json!({
+        "version": SCHEMA_VER,
         "fns": out.fns,
         "adts": out.adts,
         "statics": out.statics,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,5 +24,6 @@ extern crate rustc_target;
 pub mod analyz;
 pub mod lib_util;
 pub mod link;
+pub mod schema_ver;
 
 mod tar_stream;

--- a/src/schema_ver.rs
+++ b/src/schema_ver.rs
@@ -1,0 +1,9 @@
+/// The version of the JSON schema that `mir-json` follows. This is intended for
+/// use by downstream tools to quickly determine if they are ingesting a MIR
+/// JSON file that is compatible with the version of the schema that they are
+/// expecting.
+///
+/// Each version of the schema is assumed to be backwards-incompatible with
+/// previous versions of the schema. As such, any time this version number is
+/// bumped, it should be treated as a major version bump.
+pub const SCHEMA_VER: u64 = 1;


### PR DESCRIPTION
We now include a `"version": <N>` entry in the top-level JSON map that gets generated for each MIR JSON file, where `<N>` represents the version of the JSON schema that is used to generate the file. Going forward, any changes to the JSON schema will be accompanied by a corresponding schema version bump. I have also included some logic in `link_crates` to ensure that all of the crates being linked together use the same schema version.

Fixes #45.