### PR TITLE
Require `{CRUX,SAW}_RUST_LIBRARY_PATH` or `MIR_JSON_USE_RUSTC_LIBRARY`

### DIFF
--- a/doc/rustc.md
+++ b/doc/rustc.md
@@ -100,8 +100,8 @@ For the purposes of debugging `mir-json` itself, the environment variable
 `CRUX_RUST_LIBRARY_PATH` or `SAW_RUST_LIBRARY_PATH`, in which case
 `mir-json-rustc-wrapper` will use the vanilla standard library that comes with
 `rustc` instead of a modified version for the compilation process. Since the
-unmodified version is not supported by Crucible, `cargo-crux-test` and
-`cargo-saw-build` **will fail** when `MIR_JSON_USE_RUSTC_LIBRARY` is set.
+unmodified version is not supported by Crucible, the resulting JSON output
+**will not work** with SAW or Crux when `MIR_JSON_USE_RUSTC_LIBRARY` is set.
 
 ## Other binaries
 

--- a/doc/rustc.md
+++ b/doc/rustc.md
@@ -95,6 +95,14 @@ internal environment variables, which most users will not need to care about:
   will export all top-level functions. Otherwise, it will only export those
   functions with a `#[crux::test]` attribute.
 
+For the purposes of debugging `mir-json` itself, the environment variable
+`MIR_JSON_USE_RUSTC_LIBRARY` can be defined (with any value) instead of
+`CRUX_RUST_LIBRARY_PATH` or `SAW_RUST_LIBRARY_PATH`, in which case
+`mir-json-rustc-wrapper` will use the vanilla standard library that comes with
+`rustc` instead of a modified version for the compilation process. Since the
+unmodified version is not supported by Crucible, `cargo-crux-test` and
+`cargo-saw-build` **will fail** when `MIR_JSON_USE_RUSTC_LIBRARY` is set.
+
 ## Other binaries
 
 Besides the main binaries above, `mir-json` also provides a variety of other

--- a/src/bin/mir-json-rustc-wrapper.rs
+++ b/src/bin/mir-json-rustc-wrapper.rs
@@ -189,9 +189,9 @@ fn go() -> ExitCode {
         args.push(s.clone());
     } else if env::var_os("MIR_JSON_USE_RUSTC_LIBRARY").is_none() {
         eprintln!("Missing path to modified standard libraries for Crucible.\n\
-                   Set CRUX_RUST_LIBRARY_PATH or SAW_RUST_LIBRARY_PATH to the modified standard \n\
+                   Set CRUX_RUST_LIBRARY_PATH or SAW_RUST_LIBRARY_PATH to the modified standard\n\
                    libraries path.\n\
-                   (For debugging mir-json, you can alternatively define \n\
+                   (For debugging mir-json, you can alternatively define\n\
                    MIR_JSON_USE_RUSTC_LIBRARY, but Crucible will not work.)");
         return ExitCode::FAILURE;
     }

--- a/src/bin/mir-json-rustc-wrapper.rs
+++ b/src/bin/mir-json-rustc-wrapper.rs
@@ -181,6 +181,7 @@ fn go() -> ExitCode {
     args.push("--cfg".into());
     args.push("crux".into());
 
+    // Require either CRUX_RUST_LIBRARY_PATH, SAW_RUST_LIBRARY_PATH, or MIR_JSON_USE_RUSTC_LIBRARY.
     if let Ok(s) = env::var("CRUX_RUST_LIBRARY_PATH").or(env::var("SAW_RUST_LIBRARY_PATH")) {
         args.push("-L".into());
         args.push(s.clone());

--- a/src/bin/mir-json-rustc-wrapper.rs
+++ b/src/bin/mir-json-rustc-wrapper.rs
@@ -31,7 +31,7 @@ use std::iter;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, ExitCode};
 
 
 /// Driver callbacks that get the output filename and then stop compilation.  This is used to get
@@ -156,7 +156,7 @@ fn write_test_script(script_path: &Path, json_path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn go() {
+fn go() -> ExitCode {
     // First arg is the name of the `rustc` binary that cargo means to invoke, which we ignore.
     let mut args: Vec<String> = std::env::args().skip(1).collect();
 
@@ -187,6 +187,13 @@ fn go() {
 
         args.push("--sysroot".into());
         args.push(s.clone());
+    } else if env::var_os("MIR_JSON_USE_RUSTC_LIBRARY").is_none() {
+        eprintln!("Missing path to modified standard libraries for Crucible.\n\
+                   Set CRUX_RUST_LIBRARY_PATH or SAW_RUST_LIBRARY_PATH to the modified standard \n\
+                   libraries path.\n\
+                   (For debugging mir-json, you can alternatively define \n\
+                   MIR_JSON_USE_RUSTC_LIBRARY, but Crucible will not work.)");
+        return ExitCode::FAILURE;
     }
 
     let mut use_override_crates = HashSet::new();
@@ -216,7 +223,7 @@ fn go() {
                     export_style,
                 },
             ).run().unwrap();
-            return;
+            return ExitCode::SUCCESS;
         },
         Some(x) => x,
     };
@@ -264,8 +271,9 @@ fn go() {
 
     write_test_script(&test_path, &json_path).unwrap();
     eprintln!("generated test script {}", test_path.display());
+    ExitCode::SUCCESS
 }
 
-fn main() {
-    go();
+fn main() -> ExitCode {
+    go()
 }


### PR DESCRIPTION
Fixes #67.

I wasn't really sure how to name `MIR_JSON_USE_RUSTC_LIBRARY`, feel free to suggest something better.