### PR TITLE
Resolve cargo and rustc warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Joshua Gancher <jrg358@cornell.edu>"]
 repository = "https://github.com/GaloisInc/mir-json.git"
 license = "MIT/Apache-2.0"
+autobins = false
 
 [package.metadata.rust-analyzer]
 rustc_private=true

--- a/src/bin/cargo_test_common.rs
+++ b/src/bin/cargo_test_common.rs
@@ -81,7 +81,7 @@ fn get_override_crates(subcmd_name: &'static str, subcmd_descr: &'static str) ->
     let app = App::new(format!("cargo-{}", subcmd_name)).subcommand(cli(subcmd_name, subcmd_descr));
     let args = app.get_matches();
     let args = args.subcommand_matches(subcmd_name)
-        .unwrap_or_else(|| panic!(format!("expected {} subcommand", subcmd_name)));
+        .unwrap_or_else(|| panic!("expected {} subcommand", subcmd_name));
     let ws = args.workspace(&config)
         .unwrap_or_else(|e| panic!("error building workspace: {}", e));
     let opts = args.compile_options(

--- a/src/bin/mir-json-rustc-wrapper.rs
+++ b/src/bin/mir-json-rustc-wrapper.rs
@@ -24,8 +24,7 @@ use rustc_interface::Queries;
 use rustc_session::config::ExternLocation;
 use std::collections::HashSet;
 use std::env;
-use std::ffi::OsStr;
-use std::fs::{File, OpenOptions, read_dir};
+use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 use std::iter;
 use std::os::unix::fs::OpenOptionsExt;
@@ -66,7 +65,7 @@ impl rustc_driver::Callbacks for GetOutputPathCallbacks {
             (crate_name, outputs)
         };
         // Advance the state slightly further, initializing crate_types()
-        queries.register_plugins();
+        queries.register_plugins().unwrap();
         self.output_path = Some(rustc_session::output::out_filename(
             sess,
             sess.crate_types().first().unwrap().clone(),


### PR DESCRIPTION
- Add `autobins = false` in `Cargo.toml` to prevent auto-discovery of `cargo_test_common` as binary
- Format string directly in `panic!`
- Remove unused imports
- Unwrap discarded `Result`

There is still a cargo warning about `wrapper.rs` being present in multiple build targets, but there doesn't seem to be a way to disable it, so I'm leaving it like this for now.