### PR TITLE
Remove basic_json_impl! and basic_json_enum_impl! macros

### DIFF
--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -306,15 +306,11 @@ impl<'tcx> ToJson<'tcx> for mir::PlaceElem<'tcx> {
     }
 }
 
-basic_json_impl!(mir::BasicBlock);
-
 impl ToJson<'_> for mir::Field {
     fn to_json(&self, _mir: &mut MirState) -> serde_json::Value {
         json!(self.index())
     }
 }
-
-basic_json_impl!(mir::AssertMessage<'a>, 'a);
 
 impl<'tcx> ToJson<'tcx> for mir::Operand<'tcx> {
     fn to_json(&self, mir: &mut MirState<'_, 'tcx>) -> serde_json::Value {

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -34,8 +34,6 @@ use analyz::ty_json::*;
 use lib_util::{self, JsonOutput, EntryKind};
 use schema_ver::SCHEMA_VER;
 
-basic_json_enum_impl!(mir::UnOp);
-
 impl<'tcx> ToJson<'tcx> for abi::VariantIdx {
     fn to_json(&self, _: &mut MirState) -> serde_json::Value {
         self.as_usize().into()

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -34,8 +34,6 @@ use analyz::ty_json::*;
 use lib_util::{self, JsonOutput, EntryKind};
 use schema_ver::SCHEMA_VER;
 
-basic_json_enum_impl!(mir::BinOp);
-
 basic_json_enum_impl!(mir::NullOp);
 basic_json_enum_impl!(mir::UnOp);
 

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -34,7 +34,6 @@ use analyz::ty_json::*;
 use lib_util::{self, JsonOutput, EntryKind};
 use schema_ver::SCHEMA_VER;
 
-basic_json_enum_impl!(mir::NullOp);
 basic_json_enum_impl!(mir::UnOp);
 
 impl<'tcx> ToJson<'tcx> for abi::VariantIdx {

--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -1,7 +1,7 @@
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::def::CtorKind;
 use rustc_hir::Mutability;
-use rustc_middle::mir::{BinOp, Body, CastKind, interpret};
+use rustc_middle::mir::{BinOp, Body, CastKind, interpret, NullOp};
 use rustc_middle::ty::{self, DynKind, FloatTy, IntTy, TyCtxt, UintTy};
 use rustc_session::Session;
 use rustc_span::Span;
@@ -559,6 +559,15 @@ impl ToJson<'_> for Mutability {
         match self {
             Mutability::Not => json!({ "kind": "Not" }),
             Mutability::Mut => json!({ "kind": "Mut" }),
+        }
+    }
+}
+
+impl ToJson<'_> for NullOp {
+    fn to_json(&self, _: &mut MirState) -> serde_json::Value {
+        match self {
+            NullOp::SizeOf => json!({ "kind": "SizeOf" }),
+            NullOp::AlignOf => json!({ "kind": "AlignOf" }),
         }
     }
 }

--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -1,6 +1,6 @@
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::mir::{BinOp, Body, CastKind, interpret};
-use rustc_middle::ty::{self, DynKind, FloatTy, TyCtxt};
+use rustc_middle::ty::{self, DynKind, FloatTy, IntTy, TyCtxt};
 use rustc_session::Session;
 use rustc_span::Span;
 use rustc_span::symbol::Symbol;
@@ -489,6 +489,19 @@ impl ToJson<'_> for FloatTy {
         match self {
             FloatTy::F32 => json!({ "kind": "F32" }),
             FloatTy::F64 => json!({ "kind": "F64" }),
+        }
+    }
+}
+
+impl ToJson<'_> for IntTy {
+    fn to_json(&self, _: &mut MirState) -> serde_json::Value {
+        match self {
+            IntTy::Isize => json!({ "kind": "Isize" }),
+            IntTy::I8 => json!({ "kind": "I8" }),
+            IntTy::I16 => json!({ "kind": "I16" }),
+            IntTy::I32 => json!({ "kind": "I32" }),
+            IntTy::I64 => json!({ "kind": "I64" }),
+            IntTy::I128 => json!({ "kind": "I128" }),
         }
     }
 }

--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -1,5 +1,5 @@
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
-use rustc_middle::mir::{Body, interpret};
+use rustc_middle::mir::{Body, CastKind, interpret};
 use rustc_middle::ty::{self, TyCtxt, DynKind};
 use rustc_session::Session;
 use rustc_span::Span;
@@ -440,6 +440,23 @@ macro_rules! basic_json_enum_impl {
 }
 
 };
+}
+
+impl ToJson<'_> for CastKind {
+    fn to_json(&self, _: &mut MirState) -> serde_json::Value {
+        match self {
+            CastKind::PointerExposeAddress => json!({ "kind": "PointerExposeAddress" }),
+            CastKind::PointerFromExposedAddress => json!({ "kind": "PointerFromExposedAddress" }),
+            CastKind::DynStar => json!({ "kind": "DynStar" }),
+            CastKind::IntToInt => json!({ "kind": "IntToInt" }),
+            CastKind::FloatToInt => json!({ "kind": "FloatToInt" }),
+            CastKind::FloatToFloat => json!({ "kind": "FloatToFloat" }),
+            CastKind::IntToFloat => json!({ "kind": "IntToFloat" }),
+            CastKind::PtrToPtr => json!({ "kind": "PtrToPtr" }),
+            CastKind::FnPtrToPtr => json!({ "kind": "FnPtrToPtr" }),
+            CastKind::Pointer(_) => json!({ "kind": format!("{:?}", self) }),
+        }
+    }
 }
 
 impl<'tcx, A, B> ToJson<'tcx> for (A, B)

--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -6,6 +6,7 @@ use rustc_middle::ty::{self, DynKind, FloatTy, IntTy, TyCtxt, UintTy};
 use rustc_session::Session;
 use rustc_span::Span;
 use rustc_span::symbol::Symbol;
+use rustc_target::spec::abi::Abi;
 use serde_json;
 use std::collections::BTreeMap;
 use std::collections::{HashMap, HashSet, hash_map};
@@ -443,6 +444,42 @@ macro_rules! basic_json_enum_impl {
 }
 
 };
+}
+
+impl ToJson<'_> for Abi {
+    fn to_json(&self, _: &mut MirState) -> serde_json::Value {
+        match self {
+            Abi::Rust => json!({ "kind": "Rust" }),
+            Abi::PtxKernel => json!({ "kind": "PtxKernel" }),
+            Abi::Msp430Interrupt => json!({ "kind": "Msp430Interrupt" }),
+            Abi::X86Interrupt => json!({ "kind": "X86Interrupt" }),
+            Abi::AmdGpuKernel => json!({ "kind": "AmdGpuKernel" }),
+            Abi::EfiApi => json!({ "kind": "EfiApi" }),
+            Abi::AvrInterrupt => json!({ "kind": "AvrInterrupt" }),
+            Abi::AvrNonBlockingInterrupt => json!({ "kind": "AvrNonBlockingInterrupt" }),
+            Abi::CCmseNonSecureCall => json!({ "kind": "CCmseNonSecureCall" }),
+            Abi::Wasm => json!({ "kind": "Wasm" }),
+            Abi::RustIntrinsic => json!({ "kind": "RustIntrinsic" }),
+            Abi::RustCall => json!({ "kind": "RustCall" }),
+            Abi::PlatformIntrinsic => json!({ "kind": "PlatformIntrinsic" }),
+            Abi::Unadjusted => json!({ "kind": "Unadjusted" }),
+            Abi::RustCold => json!({ "kind": "RustCold" }),
+
+            // Data-carrying variants — use Debug formatting
+            Abi::C { .. }
+            | Abi::Cdecl { .. }
+            | Abi::Stdcall { .. }
+            | Abi::Fastcall { .. }
+            | Abi::Vectorcall { .. }
+            | Abi::Thiscall { .. }
+            | Abi::Aapcs { .. }
+            | Abi::Win64 { .. }
+            | Abi::SysV64 { .. }
+            | Abi::System { .. } => {
+                json!({ "kind": format!("{:?}", self) })
+            }
+        }
+    }
 }
 
 impl ToJson<'_> for BinOp {

--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -1,6 +1,6 @@
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::mir::{BinOp, Body, CastKind, interpret};
-use rustc_middle::ty::{self, DynKind, FloatTy, IntTy, TyCtxt};
+use rustc_middle::ty::{self, DynKind, FloatTy, IntTy, TyCtxt, UintTy};
 use rustc_session::Session;
 use rustc_span::Span;
 use rustc_span::symbol::Symbol;
@@ -502,6 +502,19 @@ impl ToJson<'_> for IntTy {
             IntTy::I32 => json!({ "kind": "I32" }),
             IntTy::I64 => json!({ "kind": "I64" }),
             IntTy::I128 => json!({ "kind": "I128" }),
+        }
+    }
+}
+
+impl ToJson<'_> for UintTy {
+    fn to_json(&self, _: &mut MirState) -> serde_json::Value {
+        match self {
+            UintTy::Usize => json!({ "kind": "Usize" }),
+            UintTy::U8 => json!({ "kind": "U8" }),
+            UintTy::U16 => json!({ "kind": "U16" }),
+            UintTy::U32 => json!({ "kind": "U32" }),
+            UintTy::U64 => json!({ "kind": "U64" }),
+            UintTy::U128 => json!({ "kind": "U128" }),
         }
     }
 }

--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -1,5 +1,5 @@
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
-use rustc_middle::mir::{Body, CastKind, interpret};
+use rustc_middle::mir::{BinOp, Body, CastKind, interpret};
 use rustc_middle::ty::{self, TyCtxt, DynKind};
 use rustc_session::Session;
 use rustc_span::Span;
@@ -440,6 +440,30 @@ macro_rules! basic_json_enum_impl {
 }
 
 };
+}
+
+impl ToJson<'_> for BinOp {
+    fn to_json(&self, _: &mut MirState) -> serde_json::Value {
+        match self {
+            BinOp::Add => json!({ "kind": "Add" }),
+            BinOp::Sub => json!({ "kind": "Sub" }),
+            BinOp::Mul => json!({ "kind": "Mul" }),
+            BinOp::Div => json!({ "kind": "Div" }),
+            BinOp::Rem => json!({ "kind": "Rem" }),
+            BinOp::BitXor => json!({ "kind": "BitXor" }),
+            BinOp::BitAnd => json!({ "kind": "BitAnd" }),
+            BinOp::BitOr => json!({ "kind": "BitOr" }),
+            BinOp::Shl => json!({ "kind": "Shl" }),
+            BinOp::Shr => json!({ "kind": "Shr" }),
+            BinOp::Eq => json!({ "kind": "Eq" }),
+            BinOp::Lt => json!({ "kind": "Lt" }),
+            BinOp::Le => json!({ "kind": "Le" }),
+            BinOp::Ne => json!({ "kind": "Ne" }),
+            BinOp::Ge => json!({ "kind": "Ge" }),
+            BinOp::Gt => json!({ "kind": "Gt" }),
+            BinOp::Offset => json!({ "kind": "Offset" }),
+        }
+    }
 }
 
 impl ToJson<'_> for CastKind {

--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -1,7 +1,7 @@
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_hir::def::CtorKind;
 use rustc_hir::Mutability;
-use rustc_middle::mir::{BinOp, Body, CastKind, interpret, NullOp};
+use rustc_middle::mir::{BinOp, Body, CastKind, interpret, NullOp, UnOp};
 use rustc_middle::ty::{self, DynKind, FloatTy, IntTy, TyCtxt, UintTy};
 use rustc_session::Session;
 use rustc_span::Span;
@@ -423,29 +423,6 @@ macro_rules! basic_json_impl {
 };
 }
 
-#[macro_export]
-macro_rules! basic_json_enum_impl {
-    ($n : path) => {
-        impl ToJson<'_> for $n {
-    fn to_json(&self, _ : &mut MirState) -> serde_json::Value {
-        let mut s = String::new();
-        write!(&mut s, "{:?}", self).unwrap();
-        json!({"kind": s})
-    }
-}
-};
-    ($n : path, $lt : tt) => {
-        impl<$lt> ToJson<'_> for $n {
-    fn to_json(&self, _ : &mut MirState) -> serde_json::Value {
-        let mut s = String::new();
-        write!(&mut s, "{:?}", self).unwrap();
-        json!({"kind": s})
-    }
-}
-
-};
-}
-
 impl ToJson<'_> for Abi {
     fn to_json(&self, _: &mut MirState) -> serde_json::Value {
         match self {
@@ -581,6 +558,15 @@ impl ToJson<'_> for UintTy {
             UintTy::U32 => json!({ "kind": "U32" }),
             UintTy::U64 => json!({ "kind": "U64" }),
             UintTy::U128 => json!({ "kind": "U128" }),
+        }
+    }
+}
+
+impl ToJson<'_> for UnOp {
+    fn to_json(&self, _: &mut MirState) -> serde_json::Value {
+        match self {
+            UnOp::Not => json!({ "kind": "Not" }),
+            UnOp::Neg => json!({ "kind": "Neg" }),
         }
     }
 }

--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -1,6 +1,6 @@
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::mir::{BinOp, Body, CastKind, interpret};
-use rustc_middle::ty::{self, TyCtxt, DynKind};
+use rustc_middle::ty::{self, DynKind, FloatTy, TyCtxt};
 use rustc_session::Session;
 use rustc_span::Span;
 use rustc_span::symbol::Symbol;
@@ -10,6 +10,7 @@ use std::collections::{HashMap, HashSet, hash_map};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::mem;
+
 
 pub struct CompileState<'a, 'tcx> {
     pub session: &'a Session,
@@ -479,6 +480,15 @@ impl ToJson<'_> for CastKind {
             CastKind::PtrToPtr => json!({ "kind": "PtrToPtr" }),
             CastKind::FnPtrToPtr => json!({ "kind": "FnPtrToPtr" }),
             CastKind::Pointer(_) => json!({ "kind": format!("{:?}", self) }),
+        }
+    }
+}
+
+impl ToJson<'_> for FloatTy {
+    fn to_json(&self, _: &mut MirState) -> serde_json::Value {
+        match self {
+            FloatTy::F32 => json!({ "kind": "F32" }),
+            FloatTy::F64 => json!({ "kind": "F64" }),
         }
     }
 }

--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -1,4 +1,5 @@
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
+use rustc_hir::Mutability;
 use rustc_middle::mir::{BinOp, Body, CastKind, interpret};
 use rustc_middle::ty::{self, DynKind, FloatTy, IntTy, TyCtxt, UintTy};
 use rustc_session::Session;
@@ -502,6 +503,15 @@ impl ToJson<'_> for IntTy {
             IntTy::I32 => json!({ "kind": "I32" }),
             IntTy::I64 => json!({ "kind": "I64" }),
             IntTy::I128 => json!({ "kind": "I128" }),
+        }
+    }
+}
+
+impl ToJson<'_> for Mutability {
+    fn to_json(&self, _: &mut MirState) -> serde_json::Value {
+        match self {
+            Mutability::Not => json!({ "kind": "Not" }),
+            Mutability::Mut => json!({ "kind": "Mut" }),
         }
     }
 }

--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -1,4 +1,5 @@
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
+use rustc_hir::def::CtorKind;
 use rustc_hir::Mutability;
 use rustc_middle::mir::{BinOp, Body, CastKind, interpret};
 use rustc_middle::ty::{self, DynKind, FloatTy, IntTy, TyCtxt, UintTy};
@@ -481,6 +482,15 @@ impl ToJson<'_> for CastKind {
             CastKind::PtrToPtr => json!({ "kind": "PtrToPtr" }),
             CastKind::FnPtrToPtr => json!({ "kind": "FnPtrToPtr" }),
             CastKind::Pointer(_) => json!({ "kind": format!("{:?}", self) }),
+        }
+    }
+}
+
+impl ToJson<'_> for CtorKind {
+    fn to_json(&self, _: &mut MirState) -> serde_json::Value {
+        match self {
+            CtorKind::Fn => json!({ "kind": "Fn" }),
+            CtorKind::Const => json!({ "kind": "Const" }),
         }
     }
 }

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -33,7 +33,6 @@ impl<'tcx, T> ToJson<'tcx> for ty::List<T>
     }
 }
 
-basic_json_enum_impl!(ty::FloatTy);
 basic_json_enum_impl!(ty::IntTy);
 basic_json_enum_impl!(ty::UintTy);
 basic_json_enum_impl!(hir::Mutability);

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -33,7 +33,6 @@ impl<'tcx, T> ToJson<'tcx> for ty::List<T>
     }
 }
 
-basic_json_enum_impl!(ty::IntTy);
 basic_json_enum_impl!(ty::UintTy);
 basic_json_enum_impl!(hir::Mutability);
 basic_json_enum_impl!(hir::def::CtorKind);

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -33,7 +33,6 @@ impl<'tcx, T> ToJson<'tcx> for ty::List<T>
     }
 }
 
-basic_json_enum_impl!(hir::def::CtorKind);
 basic_json_enum_impl!(abi::Abi);
 
 impl ToJson<'_> for mir::BorrowKind {

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -11,11 +11,9 @@ use rustc_middle::ty;
 use rustc_middle::ty::{AdtKind, DynKind, TyCtxt, TypeVisitable};
 use rustc_middle::ty::util::{IntTypeExt};
 use rustc_query_system::ich::StableHashingContext;
-use rustc_target::spec::abi;
 use rustc_target::abi::{Align, FieldsShape, HasDataLayout, Size};
 use rustc_span::DUMMY_SP;
 use serde_json;
-use std::fmt::Write as FmtWrite;
 use std::usize;
 
 use analyz::to_json::*;
@@ -32,8 +30,6 @@ impl<'tcx, T> ToJson<'tcx> for ty::List<T>
         json!(j)
     }
 }
-
-basic_json_enum_impl!(abi::Abi);
 
 impl ToJson<'_> for mir::BorrowKind {
     fn to_json(&self, _mir: &mut MirState) -> serde_json::Value {

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -33,7 +33,6 @@ impl<'tcx, T> ToJson<'tcx> for ty::List<T>
     }
 }
 
-basic_json_enum_impl!(ty::UintTy);
 basic_json_enum_impl!(hir::Mutability);
 basic_json_enum_impl!(hir::def::CtorKind);
 basic_json_enum_impl!(abi::Abi);

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -38,7 +38,6 @@ basic_json_enum_impl!(ty::IntTy);
 basic_json_enum_impl!(ty::UintTy);
 basic_json_enum_impl!(hir::Mutability);
 basic_json_enum_impl!(hir::def::CtorKind);
-basic_json_enum_impl!(mir::CastKind);
 basic_json_enum_impl!(abi::Abi);
 
 impl ToJson<'_> for mir::BorrowKind {

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -33,7 +33,6 @@ impl<'tcx, T> ToJson<'tcx> for ty::List<T>
     }
 }
 
-basic_json_enum_impl!(hir::Mutability);
 basic_json_enum_impl!(hir::def::CtorKind);
 basic_json_enum_impl!(abi::Abi);
 


### PR DESCRIPTION
Replaced the basic_json_impl! and basic_json_enum_impl! macros with explicit ToJson impls. Enum variants and types are now handled directly in code rather than through macro expansion. This avoids silent changes to the JSON schema if variant names shift between rustc versions.

This should resolve:

https://github.com/GaloisInc/mir-json/issues/72