### PR TITLE
removed erroneous env var

### DIFF
--- a/src/bin/saw-rustc.rs
+++ b/src/bin/saw-rustc.rs
@@ -34,7 +34,7 @@ fn main() {
 
     let e = Command::new(&wrapper_path)
         .args(&args)
-        .env("EXPORT_ALL", "true")
+        //.env("EXPORT_ALL", "true")
         .exec();
     unreachable!("exec failed: {:?}", e);
 }


### PR DESCRIPTION
I found that `saw-rustc` was ignoring which functions were marked with `#[crux::test]`, and I tracked the issue down to this line:

https://github.com/GaloisInc/mir-json/blob/f7ad1a48e3207264d6948e7bafd6fe82ff4444a9/src/bin/saw-rustc.rs#L37

It was unconditionally setting the environment variable `EXPORT_ALL=true`, which changes how the `mir-json` compiler plugin determines root functions for MIR export.

With `EXPORT_ALL` set, the plugin bypasses the `#[crux::test]` annotations and instead calls `init_instances_from_mono_items`:

https://github.com/GaloisInc/mir-json/blob/f7ad1a48e3207264d6948e7bafd6fe82ff4444a9/src/analyz/mod.rs#L757

This includes every function the compiler monomorphizes—even internal support routines and unused code paths. As a result, it pulls in large portions of the standard library, including formatting logic used by `panic!`, leading to massive JSON output.

By removing this environment variable, `saw-rustc` correctly limits MIR export to only those functions marked `#[crux::test]`, dramatically reducing output size and avoiding crashes when loading into SAW.

I had hoped that removing the env var would reduce the mir size even when I mark a function that calls `panic!` but that is not the case. It seems that there really is just a lot of cruft that gets pulled in by calling `panic!`.