### PR TITLE
cargo saw-build and saw rustc now output the same size json

### DIFF
--- a/src/bin/saw-rustc.rs
+++ b/src/bin/saw-rustc.rs
@@ -25,6 +25,13 @@ fn main() {
         args.push(host_triple().into());
     }
 
+    // This makes saw rustc behavior match the behavior of cargo
+    // without it the json output is much larger than that of cargo
+    if args.iter().all(|a| !a.starts_with("--edition")) {
+        args.push("--edition".into());
+        args.push("2021".into());
+    }
+
     let my_path = PathBuf::from(env::args_os().nth(0).unwrap());
     let wrapper_path = if let Some(dir) = my_path.parent() {
         dir.join("mir-json-rustc-wrapper")


### PR DESCRIPTION
After instrumenting the code to count roots, track dependency traversals, and inspect how everything was linked together, it turned out the difference was surprisingly simple.

I ran:

```
RUSTC_WRAPPER=echo cargo saw-build
```
and

```
RUSTC_WRAPPER=echo saw-rustc
```

and noticed that `cargo` was passing the `--edition` flag, while `saw-rustc` was not. That made all the difference.

Once I added `--edition 2021`, the behavior and output matched `cargo`

