### PR TITLE
Record lang items and their original IDs in the JSON output

### DIFF
--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -1062,7 +1062,9 @@ fn emit_adt<'tcx>(
     // Render the string for the original ADT definition (i.e., the ADT *before*
     // it is applied to any type arguments). If the original ADT is a lang item,
     // then this will go into the `lang_items` section of the output.
-    let (adt_orig_name, adt_orig_lang_item_name) = def_id_strs(tcx, ai.adt.did());
+    let adt_orig_did = ai.adt.did();
+    let adt_orig_name = orig_def_id_str(tcx, adt_orig_did);
+    let adt_orig_lang_item_name = lang_item_def_id_str(tcx, adt_orig_did);
     emit_lang_item(ms, out, &adt_orig_name, adt_orig_lang_item_name.as_deref())?;
 
     emit_new_defs(ms, out)?;

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -1053,9 +1053,18 @@ fn emit_adt<'tcx>(
 ) -> io::Result<()> {
     let tcx = ms.state.tcx;
 
-    let adt_name = adt_inst_id_str(tcx, ai);
-    tcx.sess.dcx().note(format!("Emitting ADT definition for {}", adt_name));
+    // Render the string for the ADT instance (i.e., the ADT applied to its type
+    // arguments). This will go into the `adts` section of the output.
+    let adt_inst_name = adt_inst_id_str(tcx, ai);
+    tcx.sess.dcx().note(format!("Emitting ADT definition for {}", adt_inst_name));
     out.emit(EntryKind::Adt, ai.to_json(ms))?;
+
+    // Render the string for the original ADT definition (i.e., the ADT *before*
+    // it is applied to any type arguments). If the original ADT is a lang item,
+    // then this will go into the `lang_items` section of the output.
+    let (adt_orig_name, adt_orig_lang_item_name) = def_id_strs(tcx, ai.adt.did());
+    emit_lang_item(ms, out, &adt_orig_name, adt_orig_lang_item_name.as_deref())?;
+
     emit_new_defs(ms, out)?;
     Ok(())
 }
@@ -1093,6 +1102,28 @@ fn emit_fn<'tcx>(
         "spread_arg": mir.spread_arg.map(|x| x.as_usize()),
     }))?;
     emit_new_defs(ms, out)
+}
+
+/// If an identifier is a lang item (i.e., if the supplied
+/// `lang_item_def_id_str` is a `Some` value), then output the lang item's ID
+/// and its original ID to `out.lang_items`. Otherwise, do nothing.
+fn emit_lang_item(
+    ms: &mut MirState,
+    out: &mut impl JsonOutput,
+    orig_def_id_str: &str,
+    lang_item_def_id_str: Option<&str>,
+) -> io::Result<()> {
+    match lang_item_def_id_str {
+        None => {
+            io::Result::Ok(())
+        },
+        Some(lang_item_def_id_str) => {
+            out.emit(EntryKind::LangItem, json!({
+                "name": lang_item_def_id_str,
+                "orig_def_id": orig_def_id_str,
+            }))
+        },
+    }
 }
 
 fn emit_new_defs(
@@ -1260,6 +1291,7 @@ pub fn analyze_nonstreaming<'tcx>(
         "traits": out.traits,
         "intrinsics": out.intrinsics,
         "tys": out.tys,
+        "lang_items": out.lang_items,
         "roots": out.roots,
     });
     sess.dcx().note(


### PR DESCRIPTION
`mir-json` now renders `DefId`s for [lang items](https://doc.rust-lang.org/nightly/unstable-book/language-features/lang-items.html) as `$lang/0::<lang_item_name>` so that we can refer to lang items directly by name. This is useful for wiring in definitions directly into `crucible-mir`, but it has the downside that SAW users will have a more difficult time looking up lang item names in SAW. For instance, one could not simply look up `core::option::Option` anymore; instead, one has to look up `$lang::Option`, which is less intuitive.

To make the lives of SAW users a little easier, this adds an additional `lang_items` field to the MIR JSON output that records each lang item `DefId` along with its original, fully qualified `DefId`. For now, we only record the `DefId`s for ADT definitions, as these are the only names for which we bother to replace their `DefId`s with `$lang::<lang_item_name>` at all. Moreover, we only do this for ADT _definitions_, not ADT _instances_, as SAW users are almost certainly going to user the former instead of the latter when looking up names.

-----

Here are the corresponding `crucible` and `saw-script` branches which make use of these changes:

* `crucible`: https://github.com/GaloisInc/crucible/tree/crux-mir-rust-1.86-lang-item-map
* `saw-script`: https://github.com/GaloisInc/saw-script/tree/saw-rust-1.86-lang-item-map

Once this PR is merged, I will merge the relevant `crucible` and `saw-script` changes as well.