### PR TITLE
`mir-json-translate-libs`: Create `out_dir` before creating temporary cargo package if `--keep-temp-build` is on, otherwise create temporary package in `env::temp_dir()`

### DIFF
--- a/src/bin/mir-json-translate-libs.rs
+++ b/src/bin/mir-json-translate-libs.rs
@@ -491,7 +491,7 @@ fn main() {
     // Set up a new cargo project for running `cargo test -Z build-std`.
     eprintln!("Creating empty cargo package...");
     let temp_dir =
-        TempDir::with_prefix_in(EMPTY_PROJECT_NAME.to_owned() + "-", out_dir)
+        TempDir::with_prefix_in(EMPTY_PROJECT_NAME.to_owned() + "-", &cwd)
             .expect("temporary directory should be able to be created");
     let empty_project_dir = if keep_temp_build {
         let path = temp_dir.into_path();


### PR DESCRIPTION
Creating it in `out_dir` would fail if `out_dir` doesn't exist yet. And we don't want to `mkdir -p outdir` because we shouldn't create any files permanently if the user is doing `--generate`. Putting it in `cwd` should be fine because it is temporary anyways.