### PR TITLE
`mir-json-translate-libs`: Make it easier to generate MIR for cross-compilation targets

### DIFF
--- a/src/bin/mir-json-translate-libs.rs
+++ b/src/bin/mir-json-translate-libs.rs
@@ -518,7 +518,17 @@ fn main() {
     eprintln!("Running cargo test...");
     let mut cargo_test_child = {
         let mut cmd = cargo_test_cmd(&empty_project_dir, target_triple);
-        cmd.arg("--message-format").arg("json").arg("--no-run");
+        cmd.arg("--message-format").arg("json")
+            .arg("--no-run")
+            // Hack: When cross-compiling, cargo test will fail without an
+            // appropriate linker installed. But we only care about compiling
+            // the std libraries to rlibs, which rustc can do on its own. So we
+            // pass a dummy linker to get cargo test to succeed at the end
+            // without actually doing any linking. This has the side benefit of
+            // making non-cross builds faster as well by skipping the linking
+            // step. Note that "true" here is the program /usr/bin/true (or
+            // similar), not just enabling the flag.
+            .env("RUSTFLAGS", "-C linker=true");
         if debug_enabled {
             cmd.arg("--verbose");
         }


### PR DESCRIPTION
Rust lets you easily run `rustc` for a non-host target by doing `rustup target add` to your toolchain. But for many targets, compilation won't actually work all the way, because `rustc` expects you to have a linker for the target platform installed, which `rustup` does not provide. However, if you are just trying to generate MIR for a certain target, this shouldn't be a requirement.

In `mir-json-translate-libs`, we run `cargo test -Zbuild-std` on a new cargo project with the appropriate target to determine how to build the standard libraries. If we don't have a linker for the given target, it will fail at the end when it tries to link the test binary, even though at that point we will have already collected all the information we need about how to compile the standard libraries. So we tell `rustc` to use a dummy linker (in this case `true`) to "link" the test binary, and since we pass `--no-run`, `cargo test` will not try to run the nonexistent test binary and will immediately succeed after invoking `true`. This way, the user does not need to have an actual cross-compilation toolchain installed just to set up and run `mir-json` with a custom target.