### PR TITLE
`mir-json-translate-libs`: In `--copy-sources` mode, only copy a library if it doesn't already exist

### DIFF
--- a/src/bin/mir-json-translate-libs.rs
+++ b/src/bin/mir-json-translate-libs.rs
@@ -605,8 +605,17 @@ fn main() {
         fs::create_dir_all(&new_sources_dir)
             .expect("creating copy-sources directory should succeed");
         fn copy(orig_dir: &Utf8Path, custom_dir: &Utf8Path) {
-            eprintln!("Copying {} to {}", orig_dir, custom_dir);
-            copy_dir(orig_dir, custom_dir);
+            if fs::exists(custom_dir)
+                .expect("copy-sources directory should be accessible")
+            {
+                eprintln!(
+                    "Skipping {}, {} already exists",
+                    orig_dir, custom_dir
+                );
+            } else {
+                eprintln!("Copying {} to {}", orig_dir, custom_dir);
+                copy_dir(orig_dir, custom_dir);
+            }
         }
         for unit in &unit_graph.units {
             if let CustomTarget::TargetLib(path_info) =

--- a/src/bin/mir-json-translate-libs.rs
+++ b/src/bin/mir-json-translate-libs.rs
@@ -441,8 +441,8 @@ fn main() {
                 .help(
                     "Instead of translating the existing custom standard \
                     libraries, copy all upstream standard library sources to \
-                    the given directory and exit (used for upgrading Rust \
-                    toolchain)",
+                    NEW_LIBS (if they don't already exist there) and exit \
+                    (used for upgrading Rust toolchain)",
                 ),
         ])
         .get_matches();


### PR DESCRIPTION
This is useful for adding support for additional targets which have target-specific standard library dependencies. For instance, `wasm32-unknown-unknown` depends on `dlmalloc` but most host OS targets do not. So running `mir-json-translate-libs --copy-sources libs --target wasm32-unknown-unknown` after already having run `mir-json-translate-libs --copy-sources libs` won't try to copy libraries other than `dlmalloc` which are already in `libs`.