### PR TITLE
libs: Patch `[T; N]::try_from(Vec<T, A>)`

### DIFF
--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -160,3 +160,9 @@ identify all of the code that was changed in each patch.
   Crux's version is not suitable for doing actual timing (it hard-codes the
   time to a fixed date), but it does simulate much more easily than the actual
   implementation.
+
+* Remove `*T` to `*[T; N]` cast in `[T; N]::try_from(Vec<T, A>)` (last applied: May 23, 2025)
+
+  Crucible does not currently support pointer casts from single elements to
+  arrays, so we implement this function by explicitly creating a
+  `MaybeUninit<[T; N]>` and copying into it.

--- a/libs/alloc/src/vec/mod.rs
+++ b/libs/alloc/src/vec/mod.rs
@@ -4063,7 +4063,12 @@ impl<T, A: Allocator, const N: usize> TryFrom<Vec<T, A>> for [T; N] {
         // We checked earlier that we have sufficient items.
         // The items will not double-drop as the `set_len`
         // tells the `Vec` not to also drop them.
-        let array = unsafe { ptr::read(vec.as_ptr() as *const [T; N]) };
-        Ok(array)
+        // let array = unsafe { ptr::read(vec.as_ptr() as *const [T; N]) };
+        // Ok(array)
+        let mut array: MaybeUninit<[T; N]> = MaybeUninit::uninit();
+        unsafe {
+            ptr::copy_nonoverlapping(vec.as_ptr(), array.as_mut_ptr() as *mut T, N);
+            Ok(array.assume_init())
+        }
     }
 }


### PR DESCRIPTION
This solution is suggested by @spernsteiner

(he described it to me verbally so any errors are mine)