### PR TITLE
`vtable_descriptor_for_cast`: Support vtable casts involving structs

### DIFF
--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -95,37 +95,85 @@ fn vtable_descriptor_for_cast<'tcx>(
         return None;
     }
 
-    // Relevant code: rustc_codegen_ssa::base::unsized_info, and other functions in that file.
-    let old_pointee = match *old_ty.kind() {
-        ty::TyKind::Ref(_, ty, _) => ty,
-        ty::TyKind::RawPtr(ty, _) => ty,
-        _ => return None,
-    };
-    let new_pointee = match *new_ty.kind() {
-        ty::TyKind::Ref(_, ty, _) => ty,
-        ty::TyKind::RawPtr(ty, _) => ty,
-        _ => return None,
-    };
+    fn vtable_descriptor_for_ref_or_ptr_cast<'tcx>(
+        tcx: TyCtxt<'tcx>,
+        old_pointee: ty::Ty<'tcx>,
+        new_pointee: ty::Ty<'tcx>,
+    ) -> Option<ty::PolyTraitRef<'tcx>> {
+        if !tcx.is_sized_raw(ty::TypingEnv::fully_monomorphized().as_query_input(old_pointee)) {
+            // We produce a vtable only for sized -> TyDynamic casts.
+            return None;
+        }
 
-    if !tcx.is_sized_raw(ty::TypingEnv::fully_monomorphized().as_query_input(old_pointee)) {
-        // We produce a vtable only for sized -> TyDynamic casts.
-        return None;
+        // Relevant code: rustc_codegen_ssa::meth::get_vtable
+        let trait_ref = match *new_pointee.kind() {
+            ty::TyKind::Dynamic(ref preds, _, _) =>
+                preds.principal().map(|pred| pred.with_self_ty(tcx, old_pointee)),
+            _ => return None,
+        };
+        let trait_ref: ty::PolyTraitRef = match trait_ref {
+            Some(x) => x,
+            // If there's no trait ref, it means the `Dynamic` predicates contain only auto traits.
+            // The vtable for this trait object is empty.
+            // TODO: handle this better (currently the output omits the "vtable" field)
+            None => return None,
+        };
+        Some(trait_ref)
     }
 
-    // Relevant code: rustc_codegen_ssa::meth::get_vtable
-    let trait_ref = match *new_pointee.kind() {
-        ty::TyKind::Dynamic(ref preds, _, _) =>
-            preds.principal().map(|pred| pred.with_self_ty(tcx, old_pointee)),
-        _ => return None,
-    };
-    let trait_ref: ty::PolyTraitRef = match trait_ref {
-        Some(x) => x,
-        // If there's no trait ref, it means the `Dynamic` predicates contain only auto traits.
-        // The vtable for this trait object is empty.
-        // TODO: handle this better (currently the output omits the "vtable" field)
-        None => return None,
-    };
-    Some(trait_ref)
+    fn instantiate_field_ty<'tcx>(
+        tcx: TyCtxt<'tcx>,
+        field_def: &ty::FieldDef,
+        args: ty::GenericArgsRef<'tcx>
+    ) -> ty::Ty<'tcx> {
+        let field_unsubst_ty = tcx.type_of(field_def.did);
+        tcx.instantiate_and_normalize_erasing_regions(
+            args, ty::TypingEnv::fully_monomorphized(), field_unsubst_ty
+        )
+    }
+
+    match (*old_ty.kind(), *new_ty.kind()) {
+        // The two base cases: we are casting between two references or two raw
+        // pointers.
+        (ty::TyKind::Ref(_, old_pointee, _), ty::TyKind::Ref(_, new_pointee, _)) =>
+            vtable_descriptor_for_ref_or_ptr_cast(tcx, old_pointee, new_pointee),
+        (ty::TyKind::RawPtr(old_pointee, _), ty::TyKind::RawPtr(new_pointee, _)) =>
+            vtable_descriptor_for_ref_or_ptr_cast(tcx, old_pointee, new_pointee),
+
+        // It is also possible to cast between two arbitrary struct values,
+        // provided that each struct type differs in exactly one field (or a
+        // field within another struct field) that supports a vtable descriptor
+        // cast. (e.g., casting from Arc<Foo> to Arc<dyn Bar>).
+        (ty::TyKind::Adt(old_adt_def, old_args), ty::TyKind::Adt(new_adt_def, new_args))
+          if old_adt_def.is_struct() && new_adt_def.is_struct() => {
+            // Compute the fields from each struct value, and ensure that there
+            // are an equal number of fields as a sanity check.
+            let old_fields = &old_adt_def.non_enum_variant().fields;
+            let new_fields = &new_adt_def.non_enum_variant().fields;
+            if old_fields.len() != new_fields.len() {
+                return None;
+            }
+
+            // Recursively walk over the fields of each struct value, and for
+            // each pair of unequal fields, recursively compute their vtable
+            // descriptor cast.
+            let mut vtable: Option<ty::PolyTraitRef<'tcx>> = None;
+            let mut unequal_fields_count: usize = 0;
+            for (old_field_def, new_field_def) in old_fields.iter().zip(new_fields.iter()) {
+                let old_field_ty = instantiate_field_ty(tcx, old_field_def, old_args);
+                let new_field_ty = instantiate_field_ty(tcx, new_field_def, new_args);
+                if old_field_ty != new_field_ty {
+                    unequal_fields_count += 1;
+                    vtable = vtable_descriptor_for_cast(mir, kind, old_field_ty, new_field_ty);
+                }
+            }
+
+            // If we have found exactly one pair of unequal fields, then use the
+            // resulting vtable descriptor cast.
+            if unequal_fields_count == 1 { vtable } else { None }
+        },
+        _ => None,
+    }
 }
 
 /// Compute the callee method for a closure-to-fnptr cast, if applicable.


### PR DESCRIPTION
Previously, `vtable_descriptor_for_cast` only supported casts where the from/to types were references or raw pointers. Besides these two types, it is also possible to have unsized coercions between structs where exactly one of the struct's underlying fields differ and require a reference/pointer cast. This is the sort of cast seen in the example in GaloisInc/crucible#1433.

This adds support for struct-related vtable casts by extending `vtable_descriptor_for_cast` as needed. When the from/to types are structs, we recursively walk over the fields of the structs to find a pair of mismatched field types, which we use to compute the vtable to use in the cast.

Fixes one half of GaloisInc/crucible#1433. (The other half will be on the `crucible-mir` side.)