### PR TITLE
Consistently format disambiguators with 8 characters

### DIFF
--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -342,7 +342,14 @@ impl<'tcx> AllocIntern<'tcx> {
         // NB: The use of :: here is important, as mir-json's dead
         // code elimination relies on it.
         // See https://github.com/GaloisInc/mir-json/issues/36.
-        let id = format!("{}/{}::{{{{alloc}}}}[{}]", crate_name, disambig, self.map.len());
+        let id = format!(
+                    "{}/{}::{{{{alloc}}}}[{}]",
+                    crate_name,
+                    // Keep this in sync with how disambiguators are formatted in
+                    // analyz::ty_json::orig_def_id_str.
+                    &disambig.to_string()[..8],
+                    self.map.len(),
+                 );
         static_def["name"] = id.clone().into();
         self.new_vals.push(static_def);
         let old = self.map.insert((alloc, ty), id.clone());

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -101,6 +101,8 @@ pub fn orig_def_id_str(
     format!(
         "{}/{}{}",
         crate_name,
+        // Keep this in sync with how disambiguators are formatted in
+        // AllocIntern::insert in src/analyz/to_json.rs.
         &disambig.to_string()[..8],
         defpath.to_string_no_crate_verbose(),
     )


### PR DESCRIPTION
Fixes #135.