### PR TITLE
Expose appropriate drop method in traits and vtables

### DIFF
--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -794,7 +794,8 @@ fn emit_trait<'tcx>(
     // glue for trait objects, we always include a drop method in emitted traits
     // (and vtables - see `build_vtable_items` below), and we always put it at
     // the beginning of the method list so that `crucible-mir` can find and call
-    // it manually.
+    // it manually. We adjust `InstanceKind::Virtual` indices to account for
+    // this extra method in `ty_json::adjust_method_index`.
     if let Some(tref) = trait_ref {
         let dyn_ty = tref.self_ty();
         let drop_inst = ty::Instance::resolve_drop_in_place(tcx, dyn_ty);
@@ -1135,7 +1136,8 @@ fn build_vtable_items<'tcx>(
     // glue for trait objects, we always include a drop method in emitted
     // vtables (and traits - see `emit_trait` above), and we always put it at
     // the beginning of the method list so that `crucible-mir` can find and call
-    // it manually.
+    // it manually. We adjust `InstanceKind::Virtual` indices to account for
+    // this extra method in `ty_json::adjust_method_index`.
     let concrete_ty = trait_ref.self_ty();
     let drop_inst = ty::Instance::resolve_drop_in_place(tcx, concrete_ty);
     let drop_def_id = drop_inst.def.def_id();

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -824,7 +824,7 @@ fn emit_trait<'tcx>(
 
     for &m in methods {
         // `m` is `None` for methods with `where Self: Sized`.  We omit these from the vtable, and
-        // adjust `InstanceKind::Virtual` indices accordingly.
+        // adjust `InstanceKind::Virtual` indices accordingly, in `ty_json::adjust_method_index`.
         let (def_id, args) = match m {
             ty::vtable::VtblEntry::Method(inst) => (inst.def.def_id(), inst.args),
             _ => continue,
@@ -1149,7 +1149,7 @@ fn build_vtable_items<'tcx>(
     }));
     for &m in methods {
         // `m` is `None` for methods with `where Self: Sized`.  We omit these from the vtable, and
-        // adjust `InstanceKind::Virtual` indices accordingly.
+        // adjust `InstanceKind::Virtual` indices accordingly, in `ty_json::adjust_method_index`.
         let (def_id, args) = match m {
             ty::vtable::VtblEntry::Method(inst) => (inst.def.def_id(), inst.args),
             _ => continue,

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -777,12 +777,50 @@ fn emit_trait<'tcx>(
     ti: TraitInst<'tcx>,
 ) -> io::Result<()> {
     let tcx = ms.tcx;
-    let methods = if let Some(tref) = ti.concrete_trait_ref(tcx) {
+    let trait_ref = ti.concrete_trait_ref(tcx);
+
+    let methods = if let Some(tref) = trait_ref {
         tcx.vtable_entries(tref)
     } else {
         &[]
     };
-    let mut items = Vec::with_capacity(methods.len());
+
+    // Reserve space for all methods plus the additional drop function.  Usually
+    // `methods` will contain a few non-`VtblEntry::Method` entries, giving us
+    // extra slots to work with, but we don't rely on that.
+    let mut items = Vec::with_capacity(methods.len() + 1);
+
+    // To get around an issue in which rustc seems not to generate proper drop
+    // glue for trait objects, we always include a drop method in emitted traits
+    // (and vtables - see `build_vtable_items` below), and we always put it at
+    // the beginning of the method list so that `crucible-mir` can find and call
+    // it manually.
+    if let Some(tref) = trait_ref {
+        let dyn_ty = tref.self_ty();
+        let drop_inst = ty::Instance::resolve_drop_in_place(tcx, dyn_ty);
+        let drop_def_id = drop_inst.def.def_id();
+        let drop_args = drop_inst.args;
+        let drop_sig = tcx.instantiate_and_normalize_erasing_regions(
+            drop_args,
+            ty::TypingEnv::fully_monomorphized(),
+            tcx.fn_sig(drop_def_id),
+        );
+        let drop_sig = tcx.instantiate_bound_regions_with_erased(drop_sig);
+        items.push(json!({
+            "kind": "Method",
+            "item_id": drop_def_id.to_json(ms),
+            "signature": drop_sig.to_json(ms),
+        }));
+    } else {
+        // I believe the only way this can happen is if this trait instance was
+        // derived from predicates (`TraitInst::from_dynamic_predicates`) with
+        // no principal trait, only marker traits. For example, `dyn Debug +
+        // Send + Sync`'s principal trait would be `Debug`, but `dyn Send +
+        // Sync` would have no principal trait, because `Send` and `Sync` are
+        // marker traits.
+        panic!("No trait ref for {:?}?", ti);
+    }
+
     for &m in methods {
         // `m` is `None` for methods with `where Self: Sized`.  We omit these from the vtable, and
         // adjust `InstanceKind::Virtual` indices accordingly.
@@ -1088,7 +1126,25 @@ fn build_vtable_items<'tcx>(
     let trait_ref = tcx.instantiate_bound_regions_with_erased(trait_ref);
     let methods = tcx.vtable_entries(trait_ref);
 
-    let mut parts = Vec::with_capacity(methods.len());
+    // Reserve space for all methods plus the additional drop function.  Usually
+    // `methods` will contain a few non-`VtblEntry::Method` entries, giving us
+    // extra slots to work with, but we don't rely on that.
+    let mut parts = Vec::with_capacity(methods.len() + 1);
+
+    // To get around an issue in which rustc seems not to generate proper drop
+    // glue for trait objects, we always include a drop method in emitted
+    // vtables (and traits - see `emit_trait` above), and we always put it at
+    // the beginning of the method list so that `crucible-mir` can find and call
+    // it manually.
+    let concrete_ty = trait_ref.self_ty();
+    let drop_inst = ty::Instance::resolve_drop_in_place(tcx, concrete_ty);
+    let drop_def_id = drop_inst.def.def_id();
+    let drop_args = drop_inst.args;
+    parts.push(json!({
+        "item_id": drop_def_id.to_json(mir),
+        // `def_id` is the name of the concrete function.
+        "def_id": get_fn_def_name(mir, drop_def_id, drop_args),
+    }));
     for &m in methods {
         // `m` is `None` for methods with `where Self: Sized`.  We omit these from the vtable, and
         // adjust `InstanceKind::Virtual` indices accordingly.

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -286,6 +286,9 @@ impl ToJson<'_> for hir::def_id::DefId {
 /// rustc's vtables have null entries for non-object-safe methods (those with `Where Self: Sized`).
 /// We omit such methods from our vtables.  This function adjusts vtable indices from rustc's way
 /// of counting to ours.
+///
+/// This function also accounts for the extra `drop_in_place` method that we
+/// include in traits/vtables in `analyz::{emit_trait,build_vtable_items}`.
 fn adjust_method_index<'tcx>(
     tcx: TyCtxt<'tcx>,
     tref: ty::Binder<'tcx, ty::TraitRef<'tcx>>,
@@ -295,6 +298,8 @@ fn adjust_method_index<'tcx>(
     methods.iter().take(raw_idx)
         .filter(|m| matches!(m, ty::vtable::VtblEntry::Method(_)))
         .count()
+        // For the extra drop method
+        + 1
 }
 
 impl<'tcx> ToJson<'tcx> for FnInst<'tcx> {


### PR DESCRIPTION
See code comments for details. In short, this allows us to manually obtain and call an appropriate drop function for a trait object in situations where rustc doesn't do so for us.