### PR TITLE
Add function for declaring uninterpreted functions

### DIFF
--- a/libs/crucible/cryptol.rs
+++ b/libs/crucible/cryptol.rs
@@ -18,6 +18,11 @@ pub fn override_<F>(f: F, module_path: &str, name: &str) {
     unimplemented!("cryptol::override")
 }
 
+/// Mark the given name to be treated as uninterpreted for the duration
+/// of the current test.
+pub fn uninterp(name: &str) {
+    unimplemented!("cryptol::uninterp")
+}
 
 #[doc(hidden)]
 #[macro_export]

--- a/libs/crucible/cryptol.rs
+++ b/libs/crucible/cryptol.rs
@@ -18,7 +18,7 @@ pub fn override_<F>(f: F, module_path: &str, name: &str) {
     unimplemented!("cryptol::override")
 }
 
-/// Mark the given name to be treated as uninterpreted for the duration
+/// Mark the given Cryptol name to be treated as uninterpreted for the duration
 /// of the current test.
 pub fn uninterp(name: &str) {
     unimplemented!("cryptol::uninterp")


### PR DESCRIPTION
Adds a new function, which is overriden to declare that a symbol should be kept uninterpreted.