### PR TITLE
analyz: `FnPtrShim`s have `RustCall` ABI

### DIFF
--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -1284,6 +1284,7 @@ fn inst_abi<'tcx>(
         },
         ty::InstanceKind::Intrinsic(_) => ExternAbi::RustIntrinsic,
         ty::InstanceKind::ClosureOnceShim { .. } => ExternAbi::RustCall,
+        ty::InstanceKind::FnPtrShim(..) => ExternAbi::RustCall,
         _ => ExternAbi::Rust,
     }
 }


### PR DESCRIPTION
This ought to bring these shims in line with how Rust defines them - see e.g. [`Fn::call`](https://doc.rust-lang.org/std/ops/trait.Fn.html#tymethod.call), which is specified as `extern "rust-call"` (as are its `FnMut` and `FnOnce` siblings).