### PR TITLE
libs: define overridable hook for `core::array::from_ref`

### DIFF
--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -173,3 +173,7 @@ identify all of the code that was changed in each patch.
   general, producing rendered constants for unions (like `MaybeUninit`) is
   difficult because we don't have a good way to detect which union variant is
   active.
+
+* Use `crucible_array_from_ref_hook` in `core::array::from_ref` (last applied: July 22, 2025)
+
+  The actual implementation uses a pointer cast that Crucible can't handle.

--- a/libs/core/src/array/mod.rs
+++ b/libs/core/src/array/mod.rs
@@ -145,8 +145,11 @@ where
 #[stable(feature = "array_from_ref", since = "1.53.0")]
 #[rustc_const_stable(feature = "const_array_from_ref_shared", since = "1.63.0")]
 pub const fn from_ref<T>(s: &T) -> &[T; 1] {
-    // SAFETY: Converting `&T` to `&[T; 1]` is sound.
-    unsafe { &*(s as *const T).cast::<[T; 1]>() }
+    const fn crucible_array_from_ref_hook<T>(r: &T) -> &[T; 1] {
+        // SAFETY: Converting `&T` to `&[T; 1]` is sound.
+        unsafe { &*(r as *const T).cast::<[T; 1]>() }
+    }
+    crucible_array_from_ref_hook(s)
 }
 
 /// Converts a mutable reference to `T` into a mutable reference to an array of length 1 (without copying).


### PR DESCRIPTION
Mimics the approach taken in `core::slice::as_array` (see a087518725ff6c352713531c65495943af54e7e1). The normal implementation of `from_ref` does not lend itself well to `crucible-mir`-driven verification, so I intend to define an override for this hook in `crucible`.