### PR TITLE
crucible: `transmute` pointers in `TypedAllocator` allocation

### DIFF
--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -177,3 +177,8 @@ identify all of the code that was changed in each patch.
 * Use `crucible_array_from_ref_hook` in `core::array::from_ref` (last applied: July 22, 2025)
 
   The actual implementation uses a pointer cast that Crucible can't handle.
+
+* Replace `NonNull::cast` with `transmute` in `TypedAllocator` allocation (last applied: July 25, 2025)
+
+  Its use of `cast`, specifically for `NonNull<[u8; N]>` pointers, can conflict
+  with Crucible's representation of arrays.

--- a/libs/crucible/alloc.rs
+++ b/libs/crucible/alloc.rs
@@ -49,7 +49,10 @@ unsafe impl<T> alloc::Allocator for TypedAllocator<T> {
         unsafe {
             let len = size_to_len::<T>(layout.size());
             let ptr = NonNull::new_unchecked(allocate::<T>(len));
-            Ok(NonNull::slice_from_raw_parts(ptr.cast::<u8>(), len))
+            Ok(NonNull::slice_from_raw_parts(
+                core::mem::transmute::<NonNull<T>, NonNull<u8>>(ptr),
+                len,
+            ))
         }
     }
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
@@ -64,7 +67,10 @@ unsafe impl<T> alloc::Allocator for TypedAllocator<T> {
         unsafe {
             let len = size_to_len::<T>(layout.size());
             let ptr = NonNull::new_unchecked(allocate_zeroed::<T>(len));
-            Ok(NonNull::slice_from_raw_parts(ptr.cast::<u8>(), len))
+            Ok(NonNull::slice_from_raw_parts(
+                core::mem::transmute::<NonNull<T>, NonNull<u8>>(ptr),
+                len,
+            ))
         }
     }
     unsafe fn grow(


### PR DESCRIPTION
Instead of using `NonNull::cast` to convert a `NonNull<T>` to a `NonNull<u8>`, use `core::mem::transmute`, to prevent downstream issues in `crucible-mir`.

`crucible-mir` gives special treatment to several casts, including from `*const [T; N]` to `*const T`. In Rust, this is a no-op, because Rust makes no distinction between pointers to arrays and pointers to their first elements. `crucible-mir`, however, uses an explicitly array-shaped representation for pointers to arrays, so when it sees such a cast, it needs to insert an index-0 operation to get the first element of its array and keep its semantics aligned with Rust's. This is unideal, but often innocuous.

It becomes nocuous when trying to allocate space for `[u8; N]`s - e.g., for a `Vec<[u8; N]>`. At this type, `TypedAllocator::allocate{,_zeroed}` will create a `NonNull<[u8; N]>` and cast it to a `NonNull<u8>`. That cast reduces to a `*const [u8; N]` to `*const u8` cast, which triggers `crucible-mir`'s aforementioned special casting rule for that case, and causes it to insert a spurious indexing operation. This makes it impossible to simulate writes of `[u8; N]`s to that allocation - e.g. via `Vec::push` - since `crucible-mir` has come to believe it can only hold `u8`s.

A fix for this rightly belongs in `crucible`, but it involves undoing its special array representation, which is pretty involved.