### PR TITLE
libs: define overridable hooks for `core::slice::from_{ref,mut}`

### DIFF
--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -186,3 +186,7 @@ identify all of the code that was changed in each patch.
 * Use `crucible_slice_from_mut_hook` in `core::slice::from_mut` (last applied: July 25, 2025)
 
   The actual implementation uses a pointer cast that Crucible can't handle.
+
+* Use `crucible_slice_from_ref_hook` in `core::slice::from_ref` (last applied: July 28, 2025)
+
+  The actual implementation uses a pointer cast that Crucible can't handle.

--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -182,3 +182,7 @@ identify all of the code that was changed in each patch.
 
   Its use of `cast`, specifically for `NonNull<[u8; N]>` pointers, can conflict
   with Crucible's representation of arrays.
+
+* Use `crucible_slice_from_mut_hook` in `core::slice::from_mut` (last applied: July 25, 2025)
+
+  The actual implementation uses a pointer cast that Crucible can't handle.

--- a/libs/core/src/slice/raw.rs
+++ b/libs/core/src/slice/raw.rs
@@ -206,7 +206,10 @@ pub const fn from_ref<T>(s: &T) -> &[T] {
 #[rustc_const_stable(feature = "const_slice_from_ref", since = "1.83.0")]
 #[must_use]
 pub const fn from_mut<T>(s: &mut T) -> &mut [T] {
-    array::from_mut(s)
+    const fn crucible_slice_from_mut_hook<T>(r: &mut T) -> &mut [T] {
+        array::from_mut(r)
+    }
+    crucible_slice_from_mut_hook(s)
 }
 
 /// Forms a slice from a pointer range.

--- a/libs/core/src/slice/raw.rs
+++ b/libs/core/src/slice/raw.rs
@@ -198,7 +198,10 @@ pub const unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a m
 #[rustc_const_stable(feature = "const_slice_from_ref_shared", since = "1.63.0")]
 #[must_use]
 pub const fn from_ref<T>(s: &T) -> &[T] {
-    array::from_ref(s)
+    const fn crucible_slice_from_ref_hook<T>(r: &T) -> &[T] {
+        array::from_ref(r)
+    }
+    crucible_slice_from_ref_hook(s)
 }
 
 /// Converts a reference to T into a slice of length 1 (without copying).


### PR DESCRIPTION
This is similar to the approach in #147, which allowed hooking `core::array::from_ref`. Truly mimicking that approach would mean working with `core::array::from_mut`, which `slice::from_mut` calls. However, `crucible`'s special array representation makes it impossible to implement an override that would alias `array::from_mut`'s input and output references, and because those references are mutable, that shortcoming would be especially noticeable.