### PR TITLE
Mark Crucible-related hook functions as `#[inline(never)]`

### DIFF
--- a/libs/core/src/array/mod.rs
+++ b/libs/core/src/array/mod.rs
@@ -145,6 +145,7 @@ where
 #[stable(feature = "array_from_ref", since = "1.53.0")]
 #[rustc_const_stable(feature = "const_array_from_ref_shared", since = "1.63.0")]
 pub const fn from_ref<T>(s: &T) -> &[T; 1] {
+    #[inline(never)] // Keep the hook around even with optimizations applied
     const fn crucible_array_from_ref_hook<T>(r: &T) -> &[T; 1] {
         // SAFETY: Converting `&T` to `&[T; 1]` is sound.
         unsafe { &*(r as *const T).cast::<[T; 1]>() }

--- a/libs/core/src/num/nonzero.rs
+++ b/libs/core/src/num/nonzero.rs
@@ -370,6 +370,7 @@ where
     #[must_use]
     #[inline]
     pub const fn new(n: T) -> Option<Self> {
+        #[inline(never)] // Keep the hook around even with optimizations applied
         const fn crucible_non_zero_new_hook<T: ZeroablePrimitive>(n: T) -> Option<NonZero<T>> {
             // SAFETY: Memory layout optimization guarantees that `Option<NonZero<T>>` has
             //         the same layout and size as `T`, with `0` representing `None`.

--- a/libs/core/src/ptr/mod.rs
+++ b/libs/core/src/ptr/mod.rs
@@ -550,6 +550,7 @@ pub unsafe fn drop_in_place<T: ?Sized>(to_drop: *mut T) {
 #[rustc_const_stable(feature = "const_ptr_null", since = "1.24.0")]
 #[rustc_diagnostic_item = "ptr_null"]
 pub const fn null<T: ?Sized + Thin>() -> *const T {
+    #[inline(never)] // Keep the hook around even with optimizations applied
     const fn crucible_null_hook<T: ?Sized + Thin>() -> *const T {
         from_raw_parts(without_provenance::<()>(0), ())
     }
@@ -578,6 +579,7 @@ pub const fn null<T: ?Sized + Thin>() -> *const T {
 #[rustc_const_stable(feature = "const_ptr_null", since = "1.24.0")]
 #[rustc_diagnostic_item = "ptr_null_mut"]
 pub const fn null_mut<T: ?Sized + Thin>() -> *mut T {
+    #[inline(never)] // Keep the hook around even with optimizations applied
     const fn crucible_null_hook<T: ?Sized + Thin>() -> *mut T {
         from_raw_parts_mut(without_provenance_mut::<()>(0), ())
     }
@@ -888,6 +890,7 @@ pub const fn from_mut<T: ?Sized>(r: &mut T) -> *mut T {
 #[rustc_const_stable(feature = "const_slice_from_raw_parts", since = "1.64.0")]
 #[rustc_diagnostic_item = "ptr_slice_from_raw_parts"]
 pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
+    #[inline(never)] // Keep the hook around even with optimizations applied
     const fn crucible_slice_from_raw_parts_hook<T>(data: *const T, len: usize) -> *const [T] {
         from_raw_parts(data, len)
     }
@@ -937,6 +940,7 @@ pub const fn slice_from_raw_parts<T>(data: *const T, len: usize) -> *const [T] {
 #[rustc_const_stable(feature = "const_slice_from_raw_parts_mut", since = "1.83.0")]
 #[rustc_diagnostic_item = "ptr_slice_from_raw_parts_mut"]
 pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
+    #[inline(never)] // Keep the hook around even with optimizations applied
     const fn crucible_slice_from_raw_parts_hook<T>(data: *mut T, len: usize) -> *mut [T] {
         from_raw_parts_mut(data, len)
     }

--- a/libs/core/src/slice/mod.rs
+++ b/libs/core/src/slice/mod.rs
@@ -861,6 +861,7 @@ impl<T> [T] {
     #[inline]
     #[must_use]
     pub const fn as_array<const N: usize>(&self) -> Option<&[T; N]> {
+        #[inline(never)] // Keep the hook around even with optimizations applied
         const fn crucible_array_from_slice_hook<T, const N: usize>(
             slice: &[T],
             len: usize,

--- a/libs/core/src/slice/raw.rs
+++ b/libs/core/src/slice/raw.rs
@@ -198,6 +198,7 @@ pub const unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a m
 #[rustc_const_stable(feature = "const_slice_from_ref_shared", since = "1.63.0")]
 #[must_use]
 pub const fn from_ref<T>(s: &T) -> &[T] {
+    #[inline(never)] // Keep the hook around even with optimizations applied
     const fn crucible_slice_from_ref_hook<T>(r: &T) -> &[T] {
         array::from_ref(r)
     }
@@ -209,6 +210,7 @@ pub const fn from_ref<T>(s: &T) -> &[T] {
 #[rustc_const_stable(feature = "const_slice_from_ref", since = "1.83.0")]
 #[must_use]
 pub const fn from_mut<T>(s: &mut T) -> &mut [T] {
+    #[inline(never)] // Keep the hook around even with optimizations applied
     const fn crucible_slice_from_mut_hook<T>(r: &mut T) -> &mut [T] {
         array::from_mut(r)
     }


### PR DESCRIPTION
Fixes #153.