### PR TITLE
`libs`: Don't require `Symbolic::symbolic`'s argument to be `'static`

### DIFF
--- a/libs/crucible/array.rs
+++ b/libs/crucible/array.rs
@@ -50,12 +50,12 @@ impl<T: Copy> Array<T> {
     }
 }
 
-fn symbolic<T>(desc: &'static str) -> Array<T> {
+fn symbolic<T>(desc: &str) -> Array<T> {
     unimplemented!("Array::symbolic")
 }
 
 impl<T> Symbolic for Array<T> {
-    fn symbolic(desc: &'static str) -> Array<T> {
+    fn symbolic(desc: &str) -> Array<T> {
         symbolic(desc)
     }
 }

--- a/libs/crucible/bitvector.rs
+++ b/libs/crucible/bitvector.rs
@@ -12,22 +12,22 @@ pub struct Bv<S: Size + ?Sized> {
 }
 
 pub trait Size {
-    fn make_symbolic(desc: &'static str) -> Bv<Self>;
+    fn make_symbolic(desc: &str) -> Bv<Self>;
 }
 
 pub struct _128;
 impl Size for _128 {
-    fn make_symbolic(desc: &'static str) -> Bv<Self> { make_symbolic_128(desc) }
+    fn make_symbolic(desc: &str) -> Bv<Self> { make_symbolic_128(desc) }
 }
 
 pub struct _256;
 impl Size for _256 {
-    fn make_symbolic(desc: &'static str) -> Bv<Self> { make_symbolic_256(desc) }
+    fn make_symbolic(desc: &str) -> Bv<Self> { make_symbolic_256(desc) }
 }
 
 pub struct _512;
 impl Size for _512 {
-    fn make_symbolic(desc: &'static str) -> Bv<Self> { make_symbolic_512(desc) }
+    fn make_symbolic(desc: &str) -> Bv<Self> { make_symbolic_512(desc) }
 }
 
 
@@ -247,12 +247,12 @@ impl<S: Size> Ord for Bv<S> {
 }
 
 impl<S: Size> Symbolic for Bv<S> {
-    fn symbolic(desc: &'static str) -> Bv<S> {
+    fn symbolic(desc: &str) -> Bv<S> {
         S::make_symbolic(desc)
     }
 }
 
 // Override hooks for constructing symbolic bitvectors.
-fn make_symbolic_128(desc: &'static str) -> Bv<_128> { unimplemented!() }
-fn make_symbolic_256(desc: &'static str) -> Bv<_256> { unimplemented!() }
-fn make_symbolic_512(desc: &'static str) -> Bv<_512> { unimplemented!() }
+fn make_symbolic_128(desc: &str) -> Bv<_128> { unimplemented!() }
+fn make_symbolic_256(desc: &str) -> Bv<_256> { unimplemented!() }
+fn make_symbolic_512(desc: &str) -> Bv<_512> { unimplemented!() }

--- a/libs/crucible/sym_bytes.rs
+++ b/libs/crucible/sym_bytes.rs
@@ -23,7 +23,7 @@ impl SymBytes {
     /// Create a new byte array, filling slots `0 .. len` with symbolic values.
     ///
     /// This is like the trait method `Symbolic::symbolic`, but takes an additional `len` argument.
-    pub fn symbolic(desc: &'static str, len: usize) -> SymBytes {
+    pub fn symbolic(desc: &str, len: usize) -> SymBytes {
         SymBytes {
             arr: Array::symbolic(desc),
             len,
@@ -34,7 +34,7 @@ impl SymBytes {
     /// the result with `f`.
     ///
     /// This is like the trait method `Symbolic::symbolic`, but takes an additional `len` argument.
-    pub fn symbolic_where<F>(desc: &'static str, len: usize, f: F) -> SymBytes
+    pub fn symbolic_where<F>(desc: &str, len: usize, f: F) -> SymBytes
     where F: FnOnce(&Self) -> bool {
         let s = Self::symbolic(desc, len);
         crucible_assume!(f(&s));

--- a/libs/crucible/symbolic.rs
+++ b/libs/crucible/symbolic.rs
@@ -5,11 +5,11 @@ use core::num::Wrapping;
 pub trait Symbolic: Sized {
     /// Create a new symbolic value of this type.  `desc` is used to refer to this symbolic value
     /// when printing counterexamples.
-    fn symbolic(desc: &'static str) -> Self;
+    fn symbolic(desc: &str) -> Self;
 
     /// Create a new symbolic value, subject to constraints.  The result is a symbolic value of
     /// this type on which `f` returns `true`.
-    fn symbolic_where<F: FnOnce(&Self) -> bool>(desc: &'static str, f: F) -> Self {
+    fn symbolic_where<F: FnOnce(&Self) -> bool>(desc: &str, f: F) -> Self {
         let x = Self::symbolic(desc);
         super::crucible_assume!(f(&x));
         x
@@ -22,10 +22,10 @@ macro_rules! uint_impls {
         $(
             /// Hook for a crucible override that creates a symbolic instance of $ty.
             #[allow(unused)]
-            fn $func(desc: &'static str) -> $ty { unimplemented!(stringify!($func)); }
+            fn $func(desc: &str) -> $ty { unimplemented!(stringify!($func)); }
 
             impl Symbolic for $ty {
-                fn symbolic(desc: &'static str) -> $ty { $func(desc) }
+                fn symbolic(desc: &str) -> $ty { $func(desc) }
             }
         )*
     };
@@ -45,7 +45,7 @@ macro_rules! usize_impls {
         $(
             #[cfg(target_pointer_width = $width)]
             impl Symbolic for usize {
-                fn symbolic(desc: &'static str) -> usize { <$ty>::symbolic(desc) as usize }
+                fn symbolic(desc: &str) -> usize { <$ty>::symbolic(desc) as usize }
             }
         )*
     };
@@ -64,7 +64,7 @@ macro_rules! int_impls {
     ($($ty:ty, $uty:ty;)*) => {
         $(
             impl Symbolic for $ty {
-                fn symbolic(desc: &'static str) -> $ty { <$uty>::symbolic(desc) as $ty }
+                fn symbolic(desc: &str) -> $ty { <$uty>::symbolic(desc) as $ty }
             }
         )*
     };
@@ -80,7 +80,7 @@ int_impls! {
 }
 
 impl Symbolic for bool {
-    fn symbolic(desc: &'static str) -> bool {
+    fn symbolic(desc: &str) -> bool {
         let val = u8::symbolic_where(desc, |&x| x < 2);
         val == 1
     }
@@ -88,7 +88,7 @@ impl Symbolic for bool {
 
 
 impl<T: Symbolic, const N: usize> Symbolic for [T; N] {
-    fn symbolic(desc: &'static str) -> [T; N] {
+    fn symbolic(desc: &str) -> [T; N] {
         array::from_fn(|_i| T::symbolic(desc))
     }
 }
@@ -99,7 +99,7 @@ macro_rules! tuple_impls {
         $(
             #[allow(unused)] #[allow(bad_style)]
             impl<$($name: Symbolic,)*> Symbolic for ($($name,)*) {
-                fn symbolic(desc: &'static str) -> ($($name,)*) {
+                fn symbolic(desc: &str) -> ($($name,)*) {
                     (
                         $($name::symbolic(desc),)*
                     )
@@ -127,7 +127,7 @@ tuple_impls! {
 
 
 impl<T: Symbolic> Symbolic for Wrapping<T> {
-    fn symbolic(desc: &'static str) -> Wrapping<T> {
+    fn symbolic(desc: &str) -> Wrapping<T> {
         Wrapping(T::symbolic(desc))
     }
 }


### PR DESCRIPTION
Fixes #157.