### PR TITLE
Add a field to track which of the roots are tests

### DIFF
--- a/SCHEMA_CHANGELOG.md
+++ b/SCHEMA_CHANGELOG.md
@@ -3,6 +3,11 @@ The following document describes the changes to the JSON schema that
 as a changelog for the code in the `mir-json` tools themselves, which are
 versioned separately.)
 
+## 4
+
+Add a field `tests`, subset of `roots`, which rememebers which of the
+roots were marked as tests.
+
 ## 3
 
 Emit layout information (size and alignment) for sized types.

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -965,7 +965,8 @@ fn init_instances_from_tests(ms: &mut MirState, out: &mut impl JsonOutput) -> io
     let tcx = ms.tcx;
     for &local_def_id in tcx.mir_keys(()) {
         let def_id = local_def_id.to_def_id();
-        if ms.export_style == ExportStyle::ExportCruxTests && !has_test_attr(tcx, def_id) {
+        let is_test = has_test_attr(tcx, def_id);
+        if ms.export_style == ExportStyle::ExportCruxTests && !is_test {
             continue;
         }
 
@@ -1010,7 +1011,7 @@ fn init_instances_from_tests(ms: &mut MirState, out: &mut impl JsonOutput) -> io
             });
 
         ms.used.instances.insert(inst.into());
-        out.add_root(inst_id_str(tcx, inst))?;
+        out.add_root(inst_id_str(tcx, inst), is_test)?;
     }
     Ok(())
 }

--- a/src/bin/cargo_test_common.rs
+++ b/src/bin/cargo_test_common.rs
@@ -168,6 +168,10 @@ pub fn cargo_test_common(subcmd_name: &'static str, subcmd_descr: &'static str,
         args.push("--target".into());
         args.push(host_tuple().into());
     }
+    let mut export_all = false;
+    if orig_args.iter().any(|a| a == "--branch-coverage") {
+        export_all = true;
+    }
     for extra_arg in extra_args {
         args.push(extra_arg.into());
     }
@@ -186,6 +190,7 @@ pub fn cargo_test_common(subcmd_name: &'static str, subcmd_descr: &'static str,
     cmd.args(&args)
        .env("RUSTC_WRAPPER", wrapper_path)
        .env("CRUX_USE_OVERRIDE_CRATES", override_crates);
+    if export_all { cmd.env("EXPORT_ALL","true"); }
     for (extra_env_var_name, extra_env_var_val) in extra_env_vars {
         cmd.env(extra_env_var_name, extra_env_var_val);
     }

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -339,13 +339,14 @@ impl<W: Write> Emitter<W> {
 
         let j_roots = j["roots"].as_array()
             .unwrap_or_else(|| panic!("expected \"roots\" table to be an array"));
-        let j_tests = j["tests"].as_array();
+        
+        let mut j_tests = HashSet::new();
+        if let Some(tests) = j["tests"].as_array() {
+          for i in tests.into_iter() { j_tests.insert(i); }
+        };
 
         for x in j_roots {
-            let is_test = match j_tests {
-                Some(tests) => tests.contains(x),
-                None => false
-            };
+            let is_test = j_tests.contains(x);
             self.add_root(x.as_str().unwrap().into(), is_test);
         }
 

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -39,7 +39,11 @@ pub struct CrateIndex {
 
     pub items: HashMap<StringId, ItemData>,
 
+    /// Translation roots
     pub roots: Vec<StringId>,
+
+    /// Subsets of roots marked with crux-test
+    pub tests: Vec<StringId>,
 
     /// The schema version in use. (See also `SCHEMA_VER`.)
     pub version: u64,
@@ -176,6 +180,7 @@ struct EmitterState {
     dep_map: HashMap<StringId, HashSet<StringId>>,
     entry_loc: HashMap<(StringId, EntryKind), (u64, u64)>,
     roots: HashSet<StringId>,
+    tests: HashSet<StringId>,
     intern: InternTable,
 }
 
@@ -227,9 +232,10 @@ impl EmitterState {
         Ok(())
     }
 
-    fn add_root(&mut self, s: Cow<str>) {
+    fn add_root(&mut self, s: Cow<str>, is_test: bool) {
         let name_id = self.intern.intern(s);
         self.roots.insert(name_id);
+        if is_test { self.tests.insert(name_id); }
     }
 
     pub fn finish(self) -> CrateIndex {
@@ -252,9 +258,12 @@ impl EmitterState {
         let mut roots = self.roots.into_iter().collect::<Vec<_>>();
         roots.sort();
 
+        let mut tests = self.tests.into_iter().collect::<Vec<_>>();
+        tests.sort();
+
         let version = SCHEMA_VER;
 
-        CrateIndex { names, items, roots, version }
+        CrateIndex { names, items, roots, tests, version }
     }
 }
 
@@ -281,8 +290,8 @@ impl<W: Write> Emitter<W> {
         })
     }
 
-    fn add_root(&mut self, name: Cow<str>) {
-        self.state.add_root(name);
+    fn add_root(&mut self, name: Cow<str>, is_test: bool) {
+        self.state.add_root(name, is_test);
     }
 
     fn emit_table(&mut self, kind: EntryKind, j: &JsonValue) -> io::Result<()> {
@@ -322,13 +331,22 @@ impl<W: Write> Emitter<W> {
         write!(self.writer, ",")?;
         write!(self.writer, "\"roots\":")?;
         serde_json::to_writer(&mut self.writer, &j["roots"])?;
+        write!(self.writer, ",")?;
+        write!(self.writer, "\"tests\":")?;
+        serde_json::to_writer(&mut self.writer, &j["tests"])?;
         write!(self.writer, "}}")?;
         self.writer.flush()?;
 
         let j_roots = j["roots"].as_array()
             .unwrap_or_else(|| panic!("expected \"roots\" table to be an array"));
+        let j_tests = j["tests"].as_array();
+
         for x in j_roots {
-            self.add_root(x.as_str().unwrap().into());
+            let is_test = match j_tests {
+                Some(tests) => tests.contains(x),
+                None => false
+            };
+            self.add_root(x.as_str().unwrap().into(), is_test);
         }
 
         Ok(())
@@ -402,7 +420,7 @@ pub fn read_crate_index<R: Read + Seek>(mut input: R) -> serde_cbor::Result<(Cra
 
 pub trait JsonOutput {
     fn emit(&mut self, kind: EntryKind, j: serde_json::Value) -> io::Result<()>;
-    fn add_root(&mut self, name: String) -> io::Result<()>;
+    fn add_root(&mut self, name: String, is_test: bool) -> io::Result<()>;
 }
 
 #[derive(Default)]
@@ -438,8 +456,14 @@ pub struct Output {
     /// providing the original identifier, which SAW can then map back to the
     /// lang item identifier used throughout the rest of the MIR code.
     pub lang_items: Vec<serde_json::Value>,
-    /// Entry points for this crate.
+    /// Entry points for this crate.  We generate definition for all of these
+    /// and their dependencies.
     pub roots: Vec<String>,
+    /// Subsets of `roots` that corresponds to tests we want to execute.
+    /// This might differ from `roots` when we want to translate more than
+    /// we need for execution, so that we can report coverage statistics,
+    /// for example.
+    pub tests: Vec<String>,
 }
 
 impl JsonOutput for Output {
@@ -457,7 +481,8 @@ impl JsonOutput for Output {
         Ok(())
     }
 
-    fn add_root(&mut self, name: String) -> io::Result<()> {
+    fn add_root(&mut self, name: String, is_test: bool) -> io::Result<()> {
+        if is_test { self.tests.push(name.clone()) }
         self.roots.push(name);
         Ok(())
     }
@@ -509,8 +534,8 @@ impl<W: Write> JsonOutput for StreamingEmitter<W> {
         Ok(())
     }
 
-    fn add_root(&mut self, name: String) -> io::Result<()> {
-        self.inner.add_root(name.into());
+    fn add_root(&mut self, name: String, is_test: bool) -> io::Result<()> {
+        self.inner.add_root(name.into(), is_test);
         Ok(())
     }
 }
@@ -527,8 +552,8 @@ impl JsonOutput for MirStream {
         self.emitter.emit(kind, j)
     }
 
-    fn add_root(&mut self, name: String) -> io::Result<()> {
-        self.emitter.add_root(name)
+    fn add_root(&mut self, name: String, is_test: bool) -> io::Result<()> {
+        self.emitter.add_root(name, is_test)
     }
 }
 

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -340,13 +340,13 @@ impl<W: Write> Emitter<W> {
         let j_roots = j["roots"].as_array()
             .unwrap_or_else(|| panic!("expected \"roots\" table to be an array"));
         
-        let mut j_tests = HashSet::new();
-        if let Some(tests) = j["tests"].as_array() {
-          for i in tests.into_iter() { j_tests.insert(i); }
-        };
+        let j_tests = j["tests"].as_array()
+            .unwrap_or_else(|| panic!("expected \"tests\" table to be an array"));
 
+        let tests = j_tests.iter().collect::<HashSet<_>>();
+        
         for x in j_roots {
-            let is_test = j_tests.contains(x);
+            let is_test = tests.contains(x);
             self.add_root(x.as_str().unwrap().into(), is_test);
         }
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -53,14 +53,18 @@ fn assign_global_ids(
 fn collect_roots(
     indexes: &[CrateIndex],
     translate: &HashMap<(usize, StringId), StringId>,
-) -> Vec<StringId> {
+) -> (Vec<StringId>, Vec<StringId>) {
     let mut roots = Vec::new();
+    let mut tests = Vec::new();
     for (crate_num, index) in indexes.iter().enumerate() {
         for &local_id in &index.roots {
             roots.push(translate[&(crate_num, local_id)]);
         }
+        for &local_id in &index.tests {
+            tests.push(translate[&(crate_num, local_id)]);
+        }
     }
-    roots
+    (roots, tests)
 }
 
 /// Ensure that all `CrateIndex`es have the same MIR JSON schema version as the
@@ -86,7 +90,7 @@ pub fn link_crates<R, W>(inputs: &mut [R], mut output: W) -> serde_cbor::Result<
 where R: Read + Seek, W: Write {
     let (indexes, json_offsets) = read_crates(inputs)?;
     let (it, defs, translate) = assign_global_ids(&indexes);
-    let roots = collect_roots(&indexes, &translate);
+    let (roots, tests) = collect_roots(&indexes, &translate);
     check_matching_versions(&indexes)?;
 
 
@@ -165,6 +169,17 @@ where R: Read + Seek, W: Write {
             .map_err(|e| -> io::Error { e.into() })?;
     }
     write!(output, "]")?;
+    write!(output, ",")?;
+    write!(output, "\"tests\":[")?;
+    for (i, &id) in tests.iter().enumerate() {
+        if i > 0 {
+            write!(output, ",")?;
+        }
+        let name = it.name(id);
+        serde_json::to_writer(&mut output, name)
+            .map_err(|e| -> io::Error { e.into() })?;
+    }
+    write!(output, "]")?;
     write!(output, "}}")?;
 
     Ok(())
@@ -175,7 +190,7 @@ pub fn gather_calls<R: Read + Seek>(
 ) -> serde_cbor::Result<(InternTable, Vec<(StringId, StringId)>)> {
     let (indexes, _json_offsets) = read_crates(inputs)?;
     let (it, defs, translate) = assign_global_ids(&indexes);
-    let roots = collect_roots(&indexes, &translate);
+    let (roots,_) = collect_roots(&indexes, &translate);
 
     let mut calls: Vec<(StringId, StringId)> = Vec::new();
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -50,6 +50,9 @@ fn assign_global_ids(
     (it, defs, translate)
 }
 
+/// Returns `(roots,tests)`, where the `roots` are all top
+/// level definitions used in the translation, and `tests` is
+/// the subset of `roots` that's marked as a `crux-test`.
 fn collect_roots(
     indexes: &[CrateIndex],
     translate: &HashMap<(usize, StringId), StringId>,

--- a/src/schema_ver.rs
+++ b/src/schema_ver.rs
@@ -6,4 +6,4 @@
 /// Each version of the schema is assumed to be backwards-incompatible with
 /// previous versions of the schema. As such, any time this version number is
 /// bumped, it should be treated as a major version bump.
-pub const SCHEMA_VER: u64 = 3;
+pub const SCHEMA_VER: u64 = 4;


### PR DESCRIPTION
A more general approach would be to keep all
attributes as part of the translation, but
for the moment this is sufficient.