### PR TITLE
Add regression tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -125,3 +125,35 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}
+
+  run-regression-tests:
+    runs-on: ${{ matrix.runner }}
+    needs: [build-image]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: digests
+
+      - name: Extract digest
+        id: digest
+        run: echo "digest=sha256:$(ls digests | head -n1)" >> $GITHUB_OUTPUT
+
+      - name: Run regression tests in Docker
+        run: |
+          docker run --rm \
+            -v "$PWD":"$PWD" \
+            -w "$PWD" \
+            ghcr.io/galoisinc/mir-json@${{ steps.digest.outputs.digest }} \
+            ./mir-json/tests/run-all.sh

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Default tool locations; override in CI
+export MIR_JSON="${MIR_JSON:-mir-json}"
+export SAW_RUSTC="${SAW_RUSTC:-saw-rustc}"
+
+# Fail if a command panics
+expect_no_panic() {
+  set +e
+  output=$("$@" 2>&1)
+  status=$?
+  set -e
+
+  if echo "$output" | grep -q 'panicked at'; then
+    echo "Panic detected"
+    echo "$output"
+    return 1
+  fi
+
+  if [[ $status -ne 0 ]]; then
+    echo "Non-zero exit: $status"
+    echo "$output"
+    return 1
+  fi
+
+  echo "No panic"
+}

--- a/tests/disabled_tests.txt
+++ b/tests/disabled_tests.txt
@@ -1,0 +1,1 @@
+# Disable test dirs here

--- a/tests/issues/test0128/README.md
+++ b/tests/issues/test0128/README.md
@@ -1,0 +1,15 @@
+# Test 0128: Projection Predicate Panic Reproducer
+
+This test corresponds to [mir-json issue #131](https://github.com/GaloisInc/mir-json/issues/131), which documents the `ProjectionPredicate` panic.
+
+This test script uses `saw-rustc` to compile the test case and confirms that the compilation does not trigger a panic inside the `mir-json` pipeline.
+
+## Significance
+
+This test ensures regression coverage for an issue where `mir-json` did not correctly handle `ProjectionPredicate` trait bounds within trait objects, causing a panic in `to_json.rs`.
+
+## Expected Result
+
+* Pre-`23a3006`: panic at `src/analyz/to_json.rs:140`
+* Post-`23a3006`: no panic; MIR is successfully generated for `f` and associated trait definitions
+

--- a/tests/issues/test0128/test.rs
+++ b/tests/issues/test0128/test.rs
@@ -1,0 +1,12 @@
+pub trait A {
+    type Output;
+    fn a(&self) -> Self::Output;
+}
+
+pub trait B: A<Output = i32> {
+    fn b(&self) -> i32;
+}
+
+pub fn f(x: &dyn B) -> i32 {
+    x.a()
+}

--- a/tests/issues/test0128/test.sh
+++ b/tests/issues/test0128/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/../../common.sh"
+
+expect_no_panic \
+  saw-rustc test.rs \
+    --target "$(rustc -vV | awk '/host:/ {print $2}')"

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TEST_ROOT=$(dirname "$0")
+export MIR_JSON_RLIBS=/mir-json/rlibs
+source "$TEST_ROOT/common.sh"
+
+discover_tests() {
+  local base="$TEST_ROOT/issues"
+  find "$base" -maxdepth 1 -type d -name 'test*' | sort
+}
+
+load_disabled_tests() {
+  if [[ -n "${DISABLED_TESTS:-}" ]]; then
+    echo "$DISABLED_TESTS"
+  else
+    grep -v '^#' "$TEST_ROOT/disabled_tests.txt" || true
+  fi
+}
+
+main() {
+  local disabled=($(load_disabled_tests))
+  local enabled=(${ENABLED_TESTS:-})
+  local tests=()
+
+  for tdir in $(discover_tests); do
+    tname=$(basename "$tdir")
+    if [[ "${#enabled[@]}" -gt 0 && ! " ${enabled[*]} " =~ " $tname " ]]; then
+      continue
+    fi
+    if [[ " ${disabled[*]} " =~ " $tname " ]]; then
+      echo "Skipping disabled test $tname"
+      continue
+    fi
+    tests+=("$tdir")
+  done
+
+  local failures=0
+  for t in "${tests[@]}"; do
+    echo "=== Running $t ==="
+    if ! (cd "$t" && ./test.sh); then
+      echo "FAILED: $t"
+      failures=$((failures + 1))
+    fi
+  done
+
+  if [[ $failures -gt 0 ]]; then
+    echo "$failures test(s) failed"
+    exit 1
+  fi
+
+  echo "All tests passed"
+}
+
+main "$@"
+


### PR DESCRIPTION
Add GitHub Actions workflow to run regression tests using mir-json Docker image

- Adds a new CI job that uses the Docker image built in the existing workflow
- Runs regression tests using the provided `run-all.sh` script
- Ensures tests execute on both x86_64 and ARM64 via matrix strategy
- Verifies mir-json works across architectures and catches regressions