### PR TITLE
Add Regression Testing to Build Workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -125,3 +125,35 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}
+
+  run-regression-tests:
+    runs-on: ${{ matrix.runner }}
+    needs: [build-image]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: digests
+
+      - name: Extract digest
+        id: digest
+        run: echo "digest=sha256:$(ls digests | head -n1)" >> $GITHUB_OUTPUT
+
+      - name: Run regression tests in Docker
+        run: |
+          docker run --rm \
+            -v "$PWD":"$PWD" \
+            -w "$PWD" \
+            ghcr.io/galoisinc/mir-json@${{ steps.digest.outputs.digest }} \
+            ./mir-json/tests/run-all.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,7 @@ jobs:
             -v "$PWD":"$PWD" \
             -w "$PWD" \
             local-test-image -c \
-            'ls -R'
+            'ls -lR ./tests ./mir-json/rlibs; whoami; id; stat /mir-json/rlibs; ls -l /mir-json/rlibs'
 
       - name: Run regression tests
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,12 +40,12 @@ jobs:
           load: true
 
       - name: List files in container working dir (Debug)
-          run: |
-            docker run --rm \
-              -v "$PWD":"$PWD" \
-              -w "$PWD" \
-              local-test-image \
-              ls -R
+        run: |
+          docker run --rm \
+            -v "$PWD":"$PWD" \
+            -w "$PWD" \
+            local-test-image \
+            ls -R
 
       - name: Run regression tests
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,13 +39,21 @@ jobs:
           tags: local-test-image
           load: true
 
+      - name: List files in container working dir (Debug)
+          run: |
+            docker run --rm \
+              -v "$PWD":"$PWD" \
+              -w "$PWD" \
+              local-test-image \
+              ls -R
+
       - name: Run regression tests
         run: |
           docker run --rm \
             -v "$PWD":"$PWD" \
             -w "$PWD" \
             local-test-image \
-            ./mir-json/tests/run-all.sh
+            ./tests/run-all.sh
 
       - name: Log in to ghcr.io
         if: github.ref == 'refs/heads/master' &&

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,14 +3,14 @@ name: docker
 on:
   push:
     branches:
-    - '**'
+    - master
   pull_request:
 
 env:
   DOCKER_IMAGE: ghcr.io/galoisinc/mir-json
 
 jobs:
-  build-image:
+  build-test-push:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -32,33 +32,57 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,manifest-descriptor
 
+      - name: Build local test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: local-test-image
+          load: true
+
+      - name: Run regression tests
+        run: |
+          docker run --rm \
+            -v "$PWD":"$PWD" \
+            -w "$PWD" \
+            local-test-image \
+            ./mir-json/tests/run-all.sh
+
       - name: Log in to ghcr.io
+        if: github.ref == 'refs/heads/master' &&
+            github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Build both local (for testing) and push digest (for final manifest)
       - name: Build and push by digest
+        if: github.ref == 'refs/heads/master' &&
+            github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc'
         uses: docker/build-push-action@v6
         id: build
         with:
           context: .
-          tags: ${{ env.DOCKER_IMAGE }}:test-${{ runner.arch }}
+          tags: ${{ env.DOCKER_IMAGE }}
           annotations: ${{ steps.meta.outputs.annotations }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: |
-            type=image,push-by-digest=true,name-canonical=true
-            type=docker,name=${{ env.DOCKER_IMAGE }}:test-${{ runner.arch }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
+        if: github.ref == 'refs/heads/master' &&
+            github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc'
         run: |
           mkdir -p ${{ runner.temp }}/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
+        if: github.ref == 'refs/heads/master' &&
+            github.event.pull_request.head.repo.fork == false &&
+            github.repository_owner == 'GaloisInc'
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ runner.arch }}
@@ -66,31 +90,9 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  run-regression-tests:
-    runs-on: ${{ matrix.runner }}
-    needs: [build-image]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86_64
-            runner: ubuntu-22.04
-          - arch: arm64
-            runner: ubuntu-22.04-arm
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run regression tests in Docker
-        run: |
-          docker run --rm \
-            -v "$PWD":"$PWD" \
-            -w "$PWD" \
-            ${{ env.DOCKER_IMAGE }}:test-${{ matrix.arch }} \
-            ./mir-json/tests/run-all.sh
-
   push-image:
     runs-on: ubuntu-22.04
-    needs: [run-regression-tests]
+    needs: [build-test-push]
     if: github.ref == 'refs/heads/master' &&
         github.event.pull_request.head.repo.fork == false &&
         github.repository_owner == 'GaloisInc'
@@ -139,12 +141,6 @@ jobs:
           eval "docker buildx imagetools create ${ANNOTATIONS} \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.DOCKER_IMAGE }}@sha256:%s ' *)"
-
-      - name: Clean up test images
-        run: |
-          # Clean up the temporary test tags
-          docker buildx imagetools delete ${{ env.DOCKER_IMAGE }}:test-x86_64 || true
-          docker buildx imagetools delete ${{ env.DOCKER_IMAGE }}:test-arm64 || true
 
       - name: Inspect image
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -110,8 +110,6 @@ jobs:
       options: --user root
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Run regression tests
         run: test/run-all.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,6 +107,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+      options: --user root
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,13 +12,9 @@ env:
 jobs:
   build-image:
     runs-on: ${{ matrix.os }}
-    if: github.ref == 'refs/heads/master' &&
-        github.event.pull_request.head.repo.fork == false &&
-        github.repository_owner == 'GaloisInc'
     strategy:
       fail-fast: false
       matrix:
-        # Cover both x86-64 and ARM64.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
     steps:
       - uses: actions/checkout@v4
@@ -43,15 +39,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Build both local (for testing) and push digest (for final manifest)
       - name: Build and push by digest
         uses: docker/build-push-action@v6
         id: build
         with:
           context: .
-          tags: ${{ env.DOCKER_IMAGE }}
+          tags: ${{ env.DOCKER_IMAGE }}:test-${{ runner.arch }}
           annotations: ${{ steps.meta.outputs.annotations }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          outputs: |
+            type=image,push-by-digest=true,name-canonical=true,push=true
+            type=docker,name=${{ env.DOCKER_IMAGE }}:test-${{ runner.arch }}
 
       - name: Export digest
         run: |
@@ -67,14 +66,34 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  run-regression-tests:
+    runs-on: ${{ matrix.runner }}
+    needs: [build-image]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run regression tests in Docker
+        run: |
+          docker run --rm \
+            -v "$PWD":"$PWD" \
+            -w "$PWD" \
+            ${{ env.DOCKER_IMAGE }}:test-${{ matrix.arch }} \
+            ./mir-json/tests/run-all.sh
+
   push-image:
     runs-on: ubuntu-22.04
-    needs: [build-image]
+    needs: [run-regression-tests]
     if: github.ref == 'refs/heads/master' &&
         github.event.pull_request.head.repo.fork == false &&
         github.repository_owner == 'GaloisInc'
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -108,52 +127,25 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
-            type=raw,value=nightly,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
-            type=raw,value=${{ env.SCHEMA_VER }},enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+            type=raw,value=nightly
+            type=raw,value=${{ env.SCHEMA_VER }}
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: index
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
-        # Build and run a complex command line with eval to avoid wrong word splitting on spaces in the annotations.
         run: |
+          export ANNOTATIONS=$(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           eval "docker buildx imagetools create ${ANNOTATIONS} \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.DOCKER_IMAGE }}@sha256:%s ' *)"
+
+      - name: Clean up test images
+        run: |
+          # Clean up the temporary test tags
+          docker buildx imagetools delete ${{ env.DOCKER_IMAGE }}:test-x86_64 || true
+          docker buildx imagetools delete ${{ env.DOCKER_IMAGE }}:test-arm64 || true
 
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}
-
-  run-regression-tests:
-    runs-on: ${{ matrix.runner }}
-    needs: [build-image]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86_64
-            runner: ubuntu-22.04
-          - arch: arm64
-            runner: ubuntu-22.04-arm
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download digest
-        uses: actions/download-artifact@v4
-        with:
-          name: digests-${{ matrix.arch }}
-          path: digests
-
-      - name: Extract digest
-        id: digest
-        run: echo "digest=sha256:$(ls digests | head -n1)" >> $GITHUB_OUTPUT
-
-      - name: Run regression tests in Docker
-        run: |
-          docker run --rm \
-            -v "$PWD":"$PWD" \
-            -w "$PWD" \
-            ghcr.io/galoisinc/mir-json@${{ steps.digest.outputs.digest }} \
-            ./mir-json/tests/run-all.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: docker
 on:
   push:
     branches:
-    - master
+    - '**'
   pull_request:
 
 env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,15 +44,15 @@ jobs:
           docker run --rm \
             -v "$PWD":"$PWD" \
             -w "$PWD" \
-            local-test-image \
-            ls -R
+            local-test-image -c \
+            'ls -R'
 
       - name: Run regression tests
         run: |
           docker run --rm \
             -v "$PWD":"$PWD" \
             -w "$PWD" \
-            local-test-image \
+            local-test-image -c \
             ./tests/run-all.sh
 
       - name: Log in to ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,20 +2,22 @@ name: docker
 
 on:
   push:
-    branches:
-    - '**'
+    branches: [ '**' ]
   pull_request:
 
 env:
   DOCKER_IMAGE: ghcr.io/galoisinc/mir-json
 
 jobs:
-  build-test-push:
+  build-image:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        # Cover both x86-64 and ARM64.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
+    outputs:
+      x86-digest: ${{ steps.set-x86-digest.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,33 +34,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,manifest-descriptor
 
-      - name: Build local test image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          tags: local-test-image
-          load: true
-
-      - name: List files in container working dir (Debug)
-        run: |
-          docker run --rm \
-            -v "$PWD":"$PWD" \
-            -w "$PWD" \
-            local-test-image -c \
-            'ls -lR ./tests ./mir-json/rlibs; whoami; id; stat /mir-json/rlibs; ls -l /mir-json/rlibs'
-
-      - name: Run regression tests
-        run: |
-          docker run --rm \
-            -v "$PWD":"$PWD" \
-            -w "$PWD" \
-            local-test-image -c \
-            ./tests/run-all.sh
-
       - name: Log in to ghcr.io
-        if: github.ref == 'refs/heads/master' &&
-            github.event.pull_request.head.repo.fork == false &&
-            github.repository_owner == 'GaloisInc'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -66,9 +42,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push by digest
-        if: github.ref == 'refs/heads/master' &&
-            github.event.pull_request.head.repo.fork == false &&
-            github.repository_owner == 'GaloisInc'
         uses: docker/build-push-action@v6
         id: build
         with:
@@ -79,18 +52,18 @@ jobs:
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
-        if: github.ref == 'refs/heads/master' &&
-            github.event.pull_request.head.repo.fork == false &&
-            github.repository_owner == 'GaloisInc'
         run: |
           mkdir -p ${{ runner.temp }}/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
+      - name: Set x86 digest output
+        id: set-x86-digest
+        if: runner.arch == 'X64'
+        run: |
+          echo "digest=${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+
       - name: Upload digest
-        if: github.ref == 'refs/heads/master' &&
-            github.event.pull_request.head.repo.fork == false &&
-            github.repository_owner == 'GaloisInc'
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ runner.arch }}
@@ -98,12 +71,58 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  tag-x86-image:
+    runs-on: ubuntu-22.04
+    needs: [build-image]
+    outputs:
+      test-tag: ${{ steps.set-tag.outputs.tag }}
+    steps:
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate test tag
+        id: set-tag
+        run: |
+          tag="test-${{ github.run_id }}-${{ github.run_attempt }}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Tag x86 image for testing
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ env.DOCKER_IMAGE }}:${{ steps.set-tag.outputs.tag }} \
+            ${{ env.DOCKER_IMAGE }}@${{ needs.build-image.outputs.x86-digest }}
+
+  regression-tests:
+    runs-on: ubuntu-22.04
+    needs: [build-image, tag-x86-image]
+    container:
+      image: ghcr.io/galoisinc/mir-json:${{ needs.tag-x86-image.outputs.test-tag }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Run regression tests
+        run: test/run-all.sh
+
   push-image:
     runs-on: ubuntu-22.04
-    needs: [build-test-push]
+    needs: [build-image, tag-x86-image, regression-tests]
     if: github.ref == 'refs/heads/master' &&
         github.event.pull_request.head.repo.fork == false &&
         github.repository_owner == 'GaloisInc'
+    strategy:
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -137,19 +156,27 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
-            type=raw,value=nightly
-            type=raw,value=${{ env.SCHEMA_VER }}
+            type=raw,value=nightly,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+            type=raw,value=${{ env.SCHEMA_VER }},enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: index
 
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
+        # Build and run a complex command line with eval to avoid wrong word splitting on spaces in the annotations.
         run: |
-          export ANNOTATIONS=$(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           eval "docker buildx imagetools create ${ANNOTATIONS} \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(jq -cr '.annotations | map("--annotation \"" + . + "\"") | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.DOCKER_IMAGE }}@sha256:%s ' *)"
 
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }}
+
+      - name: Clean up test tag
+        if: always()
+        run: |
+          # Note: This will fail if the tag doesn't exist, but that's okay
+          docker buildx imagetools create --tag ${{ env.DOCKER_IMAGE }}:delete-me \
+            ${{ env.DOCKER_IMAGE }}:${{ needs.tag-x86-image.outputs.test-tag }} || true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -111,8 +111,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: List directory contents for debugging
+        run: |
+          echo "Current directory: $(pwd)"
+          echo "Directory contents:"
+          ls -la
+          echo "Tests directory contents:"
+          ls -la tests/ || echo "tests/ directory not found"
+
       - name: Run regression tests
-        run: test/run-all.sh
+        run: tests/run-all.sh
 
   push-image:
     runs-on: ubuntu-22.04

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,7 +49,7 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: |
-            type=image,push-by-digest=true,name-canonical=true,push=true
+            type=image,push-by-digest=true,name-canonical=true
             type=docker,name=${{ env.DOCKER_IMAGE }}:test-${{ runner.arch }}
 
       - name: Export digest

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Default tool locations; override in CI
+export MIR_JSON="${MIR_JSON:-mir-json}"
+export SAW_RUSTC="${SAW_RUSTC:-saw-rustc}"
+
+# Fail if a command panics
+expect_no_panic() {
+  set +e
+  output=$("$@" 2>&1)
+  status=$?
+  set -e
+
+  if echo "$output" | grep -q 'panicked at'; then
+    echo "Panic detected"
+    echo "$output"
+    return 1
+  fi
+
+  if [[ $status -ne 0 ]]; then
+    echo "Non-zero exit: $status"
+    echo "$output"
+    return 1
+  fi
+
+  echo "No panic"
+}

--- a/tests/disabled_tests.txt
+++ b/tests/disabled_tests.txt
@@ -1,0 +1,1 @@
+# Disable test dirs here

--- a/tests/issues/test0128/README.md
+++ b/tests/issues/test0128/README.md
@@ -1,0 +1,15 @@
+# Test 0128: Projection Predicate Panic Reproducer
+
+This test corresponds to [mir-json issue #131](https://github.com/GaloisInc/mir-json/issues/131), which documents the `ProjectionPredicate` panic.
+
+This test script uses `saw-rustc` to compile the test case and confirms that the compilation does not trigger a panic inside the `mir-json` pipeline.
+
+## Significance
+
+This test ensures regression coverage for an issue where `mir-json` did not correctly handle `ProjectionPredicate` trait bounds within trait objects, causing a panic in `to_json.rs`.
+
+## Expected Result
+
+* Pre-`23a3006`: panic at `src/analyz/to_json.rs:140`
+* Post-`23a3006`: no panic; MIR is successfully generated for `f` and associated trait definitions
+

--- a/tests/issues/test0128/test.rs
+++ b/tests/issues/test0128/test.rs
@@ -1,0 +1,12 @@
+pub trait A {
+    type Output;
+    fn a(&self) -> Self::Output;
+}
+
+pub trait B: A<Output = i32> {
+    fn b(&self) -> i32;
+}
+
+pub fn f(x: &dyn B) -> i32 {
+    x.a()
+}

--- a/tests/issues/test0128/test.sh
+++ b/tests/issues/test0128/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/../../common.sh"
+
+expect_no_panic \
+  saw-rustc test.rs \
+    --target "$(rustc -vV | awk '/host:/ {print $2}')"

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export TEST_ROOT=$(dirname "$0")
+export MIR_JSON_RLIBS=/mir-json/rlibs
+source "$TEST_ROOT/common.sh"
+
+discover_tests() {
+  local base="$TEST_ROOT/issues"
+  find "$base" -maxdepth 1 -type d -name 'test*' | sort
+}
+
+load_disabled_tests() {
+  if [[ -n "${DISABLED_TESTS:-}" ]]; then
+    echo "$DISABLED_TESTS"
+  else
+    grep -v '^#' "$TEST_ROOT/disabled_tests.txt" || true
+  fi
+}
+
+main() {
+  local disabled=($(load_disabled_tests))
+  local enabled=(${ENABLED_TESTS:-})
+  local tests=()
+
+  for tdir in $(discover_tests); do
+    tname=$(basename "$tdir")
+    if [[ "${#enabled[@]}" -gt 0 && ! " ${enabled[*]} " =~ " $tname " ]]; then
+      continue
+    fi
+    if [[ " ${disabled[*]} " =~ " $tname " ]]; then
+      echo "Skipping disabled test $tname"
+      continue
+    fi
+    tests+=("$tdir")
+  done
+
+  local failures=0
+  for t in "${tests[@]}"; do
+    echo "=== Running $t ==="
+    if ! (cd "$t" && ./test.sh); then
+      echo "FAILED: $t"
+      failures=$((failures + 1))
+    fi
+  done
+
+  if [[ $failures -gt 0 ]]; then
+    echo "$failures test(s) failed"
+    exit 1
+  fi
+
+  echo "All tests passed"
+}
+
+main "$@"
+


### PR DESCRIPTION
This PR enhances the Docker build workflow by adding automated regression testing before pushing images to the registry. This addresses issue https://github.com/GaloisInc/mir-json/issues/131

## Workflow Improvements
- **New Job: `tag-x86-image`** - Creates a temporary test tag for the x86 image to enable testing
- **New Job: `regression-tests`** - Runs the test suite inside the Docker container before any images are pushed
- **Updated Trigger** - Changed from building only on master branch to building on all branches. The final push step still only occurs on master branch and only pushes a new nightly image if the regression tests pass.

## Test Framework Features
- Tests run against the built x86 Docker image in a containerized environment
- Test discovery from `tests/issues/` and `tests/regression/` directories
- Support for disabled tests via `disabled_tests.txt`
- Added example test for https://github.com/GaloisInc/mir-json/issues/128

## Benefits
The workflow now ensures that all images pass regression tests before being tagged and pushed to the registry.

## Open Questions
- **Nightly build behavior**: In this version the nightly build only pushes if the regressions pass. Would it be better to push regardless of test results to ensure we always have a nightly release?
- **ARM testing**: I don't think public repos have access to ARM CI runners, so I'm only testing on the x86 Docker image. Is this sufficient for now?

## Next Steps
- Add additional regression tests