### PR TITLE
Dockerfile: Install `jq` earlier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04 AS build
 
 RUN apt-get update && \
-    apt-get install -y build-essential curl && \
+    apt-get install -y build-essential curl jq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -25,7 +25,7 @@ RUN ./tests/run-all.sh
 FROM ubuntu:22.04
 
 RUN apt-get update && \
-    apt-get install -y build-essential ca-certificates jq && \
+    apt-get install -y build-essential ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
We need to ensure that `jq` is installed in the same Docker stage in which the tests are run, lest they fail with a `jq: command not found` error.

This fixes the Docker CI job errors seen [here](https://github.com/GaloisInc/mir-json/actions/runs/17684106881/job/50264836017) on `master`.