### PR TITLE
Add test case for #166

### DIFF
--- a/tests/issues/test0166/README.md
+++ b/tests/issues/test0166/README.md
@@ -1,0 +1,2 @@
+A test which ensures that [mir-json issue
+#166](https://github.com/GaloisInc/mir-json/issues/166) remains fixed.

--- a/tests/issues/test0166/test.rs
+++ b/tests/issues/test0166/test.rs
@@ -1,0 +1,14 @@
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+
+use std::ops::Coroutine;
+use std::pin::Pin;
+
+pub fn main() {
+    let mut coroutine = #[coroutine] || {
+        yield 1;
+        return "foo"
+    };
+
+    let p = Pin::new(&mut coroutine);
+    p.resume(());
+}

--- a/tests/issues/test0166/test.sh
+++ b/tests/issues/test0166/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/../../common.sh"
+
+expect_no_panic \
+  saw-rustc test.rs \
+    --target "$(rustc -vV | awk '/host:/ {print $2}')"


### PR DESCRIPTION
This adds a test case to ensure that #166 remains fixed. This builds off of the test suite infrastructure added in #165.