### PR TITLE
Add `async fn` variation to #166 test case

### DIFF
--- a/tests/issues/test0166/README.md
+++ b/tests/issues/test0166/README.md
@@ -12,4 +12,8 @@ internals of Rust's `async` machinery, as commonly used in libraries like
 Do note that `CoroutineWitness` has been removed entirely in recent Rust
 nightlies, and Rust's coroutine syntax itself is unstable. As such, this test
 case may need to be updated in a future upgrade to ensure that we have _some_
-amount of test coverage for `async`-related code.
+amount of test coverage for `async`-related code. Just in case the
+`#[coroutine]` syntax is removed entirely, I have also added another function
+that uses an `async fn` instead of using `#[coroutine]`. The assumption is that
+the former is likely to compile to the latter, but the former's syntax is
+stable than the latter's.

--- a/tests/issues/test0166/test.rs
+++ b/tests/issues/test0166/test.rs
@@ -1,9 +1,11 @@
 #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
+use std::future::Future;
 use std::ops::Coroutine;
 use std::pin::Pin;
+use std::task::{Context, Waker};
 
-pub fn main() {
+pub fn f() {
     let mut coroutine = #[coroutine] || {
         yield 1;
         return "foo"
@@ -11,4 +13,15 @@ pub fn main() {
 
     let p = Pin::new(&mut coroutine);
     p.resume(());
+}
+
+pub fn g() {
+    async fn bar() -> &'static str {
+        return "bar"
+    }
+
+    let s = bar();
+    let mut p = Box::pin(s);
+    let mut context = Context::from_waker(Waker::noop());
+    let _ = p.as_mut().poll(&mut context);
 }

--- a/tests/issues/test0166/test.sh
+++ b/tests/issues/test0166/test.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 source "$(dirname "$0")/../../common.sh"
 
 expect_no_panic \
-  saw-rustc test.rs \
+  saw-rustc --edition=2018 test.rs \
     --target "$(rustc -vV | awk '/host:/ {print $2}')"


### PR DESCRIPTION
The `async fn` syntax is more likely to be stable long-term, which should ensure that this test case can be useful in the long run. See also the discussion in https://github.com/GaloisInc/mir-json/pull/170#discussion_r2345383809 that prompted this.