### PR TITLE
`libs`: Patch `iter_next_chunk()` to preserve the call to `MaybeUninit::uninit()`

### DIFF
--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -167,7 +167,7 @@ identify all of the code that was changed in each patch.
   arrays, so we implement this function by explicitly creating a
   `MaybeUninit<[T; N]>` and copying into it.
 
-* Avoid use of `const { MaybeUninit::uninit() }` in `array::from_fn` (last applied: July 3, 2025)
+* Avoid use of `const { MaybeUninit::uninit() }` (last applied: October 10, 2025)
 
   Crucible doesn't support `MaybeUninit::uninit()` in const contexts.  In
   general, producing rendered constants for unions (like `MaybeUninit`) is


### PR DESCRIPTION
Doing so allows `crucible-mir` to use a custom override for `MaybeUninit::uninit()`. This is a requirement for `crucible-mir` to be able to support the `array_chunks` function, which is defined in terms of `iter_next_chunk()`.

Fixes https://github.com/GaloisInc/mir-json/issues/174.