### PR TITLE
Don't emit JSON for nested static items

### DIFF
--- a/tests/disabled_tests.txt
+++ b/tests/disabled_tests.txt
@@ -1,2 +1,1 @@
 # Disable test dirs here
-test0129


### PR DESCRIPTION
See `Note [Nested statics]` for an explanation of why this is safe to do.

Fixes #129.