### PR TITLE
Compile uninhabited enum constants to `zst`s

### DIFF
--- a/tests/issues/test0179/README.md
+++ b/tests/issues/test0179/README.md
@@ -1,0 +1,10 @@
+A test which ensures that `mir-json` can successfully compile a test case that
+creates a MIR constant whose type is an uninhabited enum, the subject of [issue
+#179](https://github.com/GaloisInc/mir-json/issues/179).
+
+Although one cannot create a value of an uninhabited enum type (e.g., `enum
+Void {}`) in source Rust, `rustc` _can_ create constants of these types when
+compiling to MIR. As such, `mir-json` has to be able to reckon with them. This
+test case is one such example of a program where this happens. `mir-json` deals
+with it by compiling the constant of type `Void` to a zero-sized type (`zst`)
+value, similarly to how the never type (`!`) is handled.

--- a/tests/issues/test0179/test.rs
+++ b/tests/issues/test0179/test.rs
@@ -1,0 +1,9 @@
+pub enum Void {}
+
+pub fn f(v: Void) -> Void {
+    v
+}
+
+pub fn g(v: Void) -> Void {
+    f(v)
+}

--- a/tests/issues/test0179/test.sh
+++ b/tests/issues/test0179/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/../../common.sh"
+
+expect_no_panic \
+  saw-rustc test.rs \
+    --target "$(rustc --print host-tuple)"


### PR DESCRIPTION
Fixes #179.