### PR TITLE
libs: remove unused parameter from `slice::as_array` hook

### DIFF
--- a/libs/core/src/slice/mod.rs
+++ b/libs/core/src/slice/mod.rs
@@ -862,10 +862,7 @@ impl<T> [T] {
     #[must_use]
     pub const fn as_array<const N: usize>(&self) -> Option<&[T; N]> {
         #[inline(never)] // Keep the hook around even with optimizations applied
-        const fn crucible_array_from_slice_hook<T, const N: usize>(
-            slice: &[T],
-            len: usize,
-        ) -> Option<&[T; N]> {
+        const fn crucible_array_from_slice_hook<T, const N: usize>(slice: &[T]) -> Option<&[T; N]> {
             if slice.len() == N {
                 let ptr = slice.as_ptr() as *const [T; N];
 
@@ -876,7 +873,7 @@ impl<T> [T] {
                 None
             }
         }
-        crucible_array_from_slice_hook(self, N)
+        crucible_array_from_slice_hook(self)
     }
 
     /// Gets a mutable reference to the slice's underlying array.


### PR DESCRIPTION
The Rust implementation of the hook doesn't use this parameter (it uses the generic `N` instead), and as of https://github.com/GaloisInc/crucible/pull/1580, neither does the implementation of the `crucible-mir` override.