### PR TITLE
analyz: add `needs_drop` field to types in emitted JSON

### DIFF
--- a/SCHEMA_CHANGELOG.md
+++ b/SCHEMA_CHANGELOG.md
@@ -3,6 +3,11 @@ The following document describes the changes to the JSON schema that
 as a changelog for the code in the `mir-json` tools themselves, which are
 versioned separately.)
 
+## 5
+
+Add a `needs_drop` field to interned types, tracking whether or not the type in
+question requires drop glue.
+
 ## 4
 
 Add a field `tests`, subset of `roots`, which rememebers which of the

--- a/src/analyz/to_json.rs
+++ b/src/analyz/to_json.rs
@@ -294,12 +294,14 @@ impl<'tcx> TyIntern<'tcx> {
         ty: ty::Ty<'tcx>,
         ty_j: serde_json::Value,
         layout_j: Option<serde_json::Value>,
+        needs_drop: bool,
     ) -> String {
         let id = ty_unique_id(ty, &ty_j);
         self.new_vals.push(json!({
             "name": &id,
             "ty": ty_j,
             "layout": layout_j,
+            "needs_drop": needs_drop,
         }));
         let old = self.map.insert(ty, id.clone());
         assert!(old.is_none(), "duplicate insert for type {:?}", ty);

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -624,8 +624,10 @@ impl<'tcx> ToJson<'tcx> for ty::Ty<'tcx> {
             }
         };
 
+        let needs_drop = self.needs_drop(tcx, ty::TypingEnv::fully_monomorphized());
+
         // Add the new entry to the interning table.
-        let id = mir.tys.insert(*self, ty_j, layout_j);
+        let id = mir.tys.insert(*self, ty_j, layout_j, needs_drop);
         json!(id)
     }
 }

--- a/src/schema_ver.rs
+++ b/src/schema_ver.rs
@@ -6,4 +6,4 @@
 /// Each version of the schema is assumed to be backwards-incompatible with
 /// previous versions of the schema. As such, any time this version number is
 /// bumped, it should be treated as a major version bump.
-pub const SCHEMA_VER: u64 = 4;
+pub const SCHEMA_VER: u64 = 5;


### PR DESCRIPTION
This will help downstream consumers support Rust's [`needs_drop`](https://doc.rust-lang.org/std/intrinsics/fn.needs_drop.html) intrinsic. Most immediately, it will help `crucible-mir` do so - see https://github.com/GaloisInc/crucible/issues/1611.