### PR TITLE
`has_test_attr`: Always return `false` for synthetic `DefId`s

### DIFF
--- a/tests/issues/test0187/README.md
+++ b/tests/issues/test0187/README.md
@@ -1,0 +1,10 @@
+A test which ensures that `mir-json` can successfully compile a test case
+involving an `async` closure, the subject of [issue
+#187](https://github.com/GaloisInc/mir-json/issues/187).
+
+The body of an `async` closure gives rise to a _synthetic_ (i.e.,
+compiler-generated) definitions at the MIR level, and at least as of
+`nightly-2025-02-16`, attempting to query the attributes of this synthetic
+closure body causes a panic. As such, `mir-json` has a special case for
+synthetic definitions to avoid triggering this panic, and this test case
+exercises that special case.

--- a/tests/issues/test0187/test.rs
+++ b/tests/issues/test0187/test.rs
@@ -1,0 +1,3 @@
+pub fn f() {
+    let _clo = async |x: u32| x;
+}

--- a/tests/issues/test0187/test.sh
+++ b/tests/issues/test0187/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/../../common.sh"
+
+expect_no_panic \
+  saw-rustc --edition=2018 test.rs \
+    --target "$(rustc --print host-tuple)"


### PR DESCRIPTION
Synthetic (i.e., compiler-generated) definitions will never have the `crux::test` attribute, so `has_test_attr` can always return `false` for them. Adding this as a special case works around a `mir-json` panic that occurs when trying to compile `async` closures in particular.

Fixes #187.