### PR TITLE
saw-rustc: prevent crash from --version, --help flags.

### DIFF
--- a/tests/issues/test0050/README.md
+++ b/tests/issues/test0050/README.md
@@ -1,0 +1,10 @@
+# Test 0050: saw-rustc Info Flags Crash
+
+This test corresponds to [mir-json issue
+#50](https://github.com/GaloisInc/mir-json/issues/50), which documents a crash
+when running `saw-rustc` with informational flags like `--version` or `--help`.
+
+## Expected Result
+
+* Pre-fix: Panic at `mir-json-rustc-wrapper.rs` when using `saw-rustc` with info flags
+* Post-fix: All info flags work correctly, printing the expected information without panicking

--- a/tests/issues/test0050/test.sh
+++ b/tests/issues/test0050/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/../../common.sh"
+
+expect_no_panic saw-rustc --version
+expect_no_panic saw-rustc --help
+expect_no_panic saw-rustc -h
+expect_no_panic saw-rustc --print sysroot
+expect_no_panic saw-rustc -C help
+expect_no_panic saw-rustc --explain E0308


### PR DESCRIPTION
Fixes #50.

Exits gracefully when no `output_path` is set (which happens when `rustc` is passed "informational" flags like `--version` and `--help`) instead of crashing.

Future work: handle `--version` separately (issue #77).  

