### PR TITLE
CI: Migrate from `macos-14` to `macos-15`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-22.04, macos-15]
     steps:
     - uses: actions/checkout@v4
     - name: Deps
@@ -69,7 +69,7 @@ jobs:
 
     - name: Validate schema
       env:
-        VER: 1.0.2
+        VER: 1.1
         OS_TAG: ${{ matrix.os }}
         ARCH_TAG: ${{ runner.arch }}
       run: .github/ci.sh validate_json_schema


### PR DESCRIPTION
This matches the current version of macOS that we are using in CI elsewhere (e.g., in the CI for the `crucible` and `saw-script` repos).