### PR TITLE
`libs`: Define `symbolic_bool` primitive function

### DIFF
--- a/libs/crucible/symbolic.rs
+++ b/libs/crucible/symbolic.rs
@@ -17,7 +17,7 @@ pub trait Symbolic: Sized {
 }
 
 
-macro_rules! uint_impls {
+macro_rules! core_impls {
     ($($ty:ty, $func:ident;)*) => {
         $(
             /// Hook for a crucible override that creates a symbolic instance of $ty.
@@ -31,7 +31,8 @@ macro_rules! uint_impls {
     };
 }
 
-uint_impls! {
+core_impls! {
+    bool, symbolic_bool;
     u8, symbolic_u8;
     u16, symbolic_u16;
     u32, symbolic_u32;
@@ -77,13 +78,6 @@ int_impls! {
     i64, u64;
     i128, u128;
     isize, usize;
-}
-
-impl Symbolic for bool {
-    fn symbolic(desc: &str) -> bool {
-        let val = u8::symbolic_where(desc, |&x| x < 2);
-        val == 1
-    }
 }
 
 


### PR DESCRIPTION
The previous `Symbolic` impl for `bool` was defined in terms of `symbolic_u8`, which does not play nicely with `crux-mir-comp`'s override argument matching. This reimplements the `Symbolic` impl for `bool` in terms of a new `symbolic_bool` function, which is intended to be overridden in `crucible-mir`.

Towards https://github.com/GaloisInc/saw-script/issues/2872.