### PR TITLE
`libs`: Patch `MaybeUninit::assume_init()` to avoid unsupported pointer cast

### DIFF
--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -197,6 +197,14 @@ into the main commit for that patch, and then the *Update* line can be removed.
   difficult because we don't have a good way to detect which union variant is
   active.
 
+* Remove raw pointer cast in `MaybeUninit::assume_init()` (last applied: December 11, 2025)
+
+  The implementation of `assume_init()` uses a raw pointer cast that Crucible
+  does not support in all cases. This is needed in particular to support
+  calling `array::from_fn()` to construct a length-0 array, as this would
+  otherwise require a cast from a `UnitRepr` (due to the use of a zero-sized
+  type) to a `MirAggregateRepr`, which Crucible does not support.
+
 * Use `crucible_array_from_ref_hook` in `core::array::from_ref` (last applied: November 25, 2025)
 
   The actual implementation uses a pointer cast that Crucible can't handle. See

--- a/libs/core/src/mem/maybe_uninit.rs
+++ b/libs/core/src/mem/maybe_uninit.rs
@@ -616,9 +616,7 @@ impl<T> MaybeUninit<T> {
         // This also means that `self` must be a `value` variant.
         unsafe {
             intrinsics::assert_inhabited::<T>();
-            // We do this via a raw ptr read instead of `ManuallyDrop::into_inner` so that there's
-            // no trace of `ManuallyDrop` in Miri's error messages here.
-            (&raw const self.value).cast::<T>().read()
+            ManuallyDrop::into_inner(self.value)
         }
     }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/commit/8362508989c8941ccbba26aaa8c787cc492c6fef (which debuted in Rust 1.90.0) changed the implementation of `MaybeUninit::assume_init()` to use a raw pointer cast for the sake of improving error messages in Miri. While good for Miri, this is bad for `crucible-mir`, as this pointer cast can involve distinct Crucible type representations, which is a type of cast that `crucible-mir` doesn't support. In particular, if using `array::from_fn()` to construct a length-0 array, then this would require casting from `UnitRepr` (due to the use of a zero-sized type) to a `MirAggregateRepr`, which `crucible-mir` does not currently support.

This commit reverts back to the old implementation of `assume_init()`, which does not have a problematic pointer cast.

Towards https://github.com/GaloisInc/crucible/issues/1674.