### PR TITLE
`from_trait_ref`: Fix handling of associated types

### DIFF
--- a/tests/issues/test0211/README.md
+++ b/tests/issues/test0211/README.md
@@ -1,0 +1,11 @@
+A regression test for [issue
+#211](https://github.com/GaloisInc/mir-json/issues/211). This tests
+`mir-json`'s ability to compile several types of subtraits that make use of a
+supertrait's associated type. Internally, this computes a _projection_ into the
+associated type, which must be instantiated with the correct type arguments.
+This is surprisingly tricky to get right (as seen in #211), so this tests
+various combinations of generic parameters to ensure that the logic for
+computing these projections is robust.
+
+All of these examples were minimized from the `syn` crate, which has a
+non-trivial trait hierarchy of its own.

--- a/tests/issues/test0211/test.rs
+++ b/tests/issues/test0211/test.rs
@@ -1,0 +1,147 @@
+trait Supertrait1 {
+    type AssocItem1;
+    fn f1(&self) -> Self::AssocItem1;
+}
+
+trait Subtrait1<T>: Supertrait1<AssocItem1 = T> {}
+
+impl Supertrait1 for u8 {
+    type AssocItem1 = u8;
+    fn f1(&self) -> Self::AssocItem1 {
+        *self
+    }
+}
+
+impl Subtrait1<u8> for u8 {}
+
+pub fn g1() -> u8 {
+    let b: Box<dyn Subtrait1<u8>> = Box::new(42u8);
+    b.f1()
+}
+
+/////
+
+trait Supertrait2 {
+    type AssocItem2;
+    fn f2(&self) -> Self::AssocItem2;
+}
+
+trait Subtrait2<T>: Supertrait2<AssocItem2 = T> {}
+
+impl Supertrait2 for u8 {
+    type AssocItem2 = (u8, u8);
+    fn f2(&self) -> Self::AssocItem2 {
+        (*self, *self)
+    }
+}
+
+impl Subtrait2<(u8, u8)> for u8 {}
+
+pub fn g2() -> (u8, u8) {
+    let b: Box<dyn Subtrait2<(u8, u8)>> = Box::new(42u8);
+    b.f2()
+}
+
+/////
+
+trait Supertrait3<S> {
+    type AssocItem3;
+    fn f3(&self, z: S) -> Self::AssocItem3;
+}
+
+trait Subtrait3<T>: Supertrait3<u32, AssocItem3 = T> {}
+
+impl Supertrait3<u32> for u8 {
+    type AssocItem3 = (u8, u16, u32);
+    fn f3(&self, z: u32) -> Self::AssocItem3 {
+        (*self, *self as u16, z as u32)
+    }
+}
+
+impl Subtrait3<(u8, u16, u32)> for u8 {}
+
+pub fn g3() -> (u8, u16, u32) {
+    let b: Box<dyn Subtrait3<(u8, u16, u32)>> = Box::new(42u8);
+    b.f3(27u32)
+}
+
+/////
+
+trait Supertrait4<S> {
+    type AssocItem4;
+    fn f4(&self, z: S) -> Self::AssocItem4;
+}
+
+trait Subtrait4: Supertrait4<u32, AssocItem4 = (u8, u16, u32)> {}
+
+impl Supertrait4<u32> for u8 {
+    type AssocItem4 = (u8, u16, u32);
+    fn f4(&self, z: u32) -> Self::AssocItem4 {
+        (*self, *self as u16, z as u32)
+    }
+}
+
+impl Subtrait4 for u8 {}
+
+pub fn g4() -> (u8, u16, u32) {
+    let b: Box<dyn Subtrait4> = Box::new(42u8);
+    b.f4(27u32)
+}
+
+/////
+
+trait Supertrait5<S> {
+    type AssocItem5;
+    fn f5(&self, z: S) -> Self::AssocItem5;
+}
+
+trait Subtrait5<T1, T2>: Supertrait5<T2, AssocItem5 = T1> {}
+
+impl Supertrait5<u32> for u8 {
+    type AssocItem5 = (u8, u16, u32);
+    fn f5(&self, z: u32) -> Self::AssocItem5 {
+        (*self, *self as u16, z as u32)
+    }
+}
+
+impl Subtrait5<(u8, u16, u32), u32> for u8 {}
+
+pub fn g5() -> (u8, u16, u32) {
+    let b: Box<dyn Subtrait5<(u8, u16, u32), u32>> = Box::new(42u8);
+    b.f5(27u32)
+}
+
+/////
+
+use std::ops::Deref;
+
+trait Supertrait6<T> {
+    type AssocItem6;
+    fn f6(&self) -> Self::AssocItem6;
+}
+
+impl Supertrait6<u8> for bool {
+    type AssocItem6 = u8;
+    fn f6(&self) -> Self::AssocItem6 {
+        2
+    }
+}
+
+impl Supertrait6<u16> for bool {
+    type AssocItem6 = u16;
+    fn f6(&self) -> Self::AssocItem6 {
+        3
+    }
+}
+
+trait Subtrait6: Supertrait6<u8, AssocItem6 = u8> + Supertrait6<u16, AssocItem6 = u16> {}
+
+impl Subtrait6 for bool {}
+
+pub fn g6() -> u16 {
+    let b: Box<dyn Subtrait6> = Box::new(true);
+    let br: &dyn Subtrait6 = b.deref();
+    let a: u8 = <dyn Subtrait6 as Supertrait6<u8>>::f6(br);
+    let b: u16 = <dyn Subtrait6 as Supertrait6<u16>>::f6(br);
+    (a as u16) + b
+}

--- a/tests/issues/test0211/test.sh
+++ b/tests/issues/test0211/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/../../common.sh"
+
+expect_no_panic \
+  saw-rustc --edition=2018 test.rs \
+    --target "$(rustc --print host-tuple)"


### PR DESCRIPTION
Previously, this function would take a subtrait and attempt to compute a projection for one of its supertraits' associated types by instantiating them with the type arguments for the subtrait, not the type arguments for the supertrait. This is utterly wrong, as the type is associated with the supertrait, not the subtrait. This can cause internal compiler errors when the two sets of type arguments do not match up, as seen in #211.

This fixes the issue by reworking `from_trait_ref` to better track the type arguments used to instantiate each supertrait and using them to compute the projections for each associated type.

Fixes #211.