### PR TITLE
`libs/crucible`: Define `Symbolic` impls for `Saturating` and `NonZero`

### DIFF
--- a/libs/crucible/lib.rs
+++ b/libs/crucible/lib.rs
@@ -1,6 +1,7 @@
 #![feature(allocator_api)]
 #![feature(core_intrinsics)]
 #![feature(crucible_intrinsics)]
+#![feature(nonzero_internals)]
 #![feature(unboxed_closures)]
 #![feature(tuple_trait)]
 #![no_std]


### PR DESCRIPTION
Adding an impl for `Saturating` is straightfoward. Adding an impl for `NonZero` is less straightforward, as `NonZero` is an abstract type that can only be built by using a smart constructor such as the `NonZero::new` function, which returns an `Option<NonZero<T>>` value. Thankfully, we can make use of `crucible_assume_unreachable!` to ensure that this always returns a non-zero symbolic value (i.e., that `NonZero::new` always returns a `Some`).

Fixes #216.