### PR TITLE
Add field offsets to layout info for struct-like types

### DIFF
--- a/SCHEMA_CHANGELOG.md
+++ b/SCHEMA_CHANGELOG.md
@@ -3,6 +3,12 @@ The following document describes the changes to the JSON schema that
 as a changelog for the code in the `mir-json` tools themselves, which are
 versioned separately.)
 
+## 10
+
+Add field offsets to the layout information for struct-like types.  This is
+omitted for primitives, unions, and arrays, for which the field offsets are
+easy to compute if needed.
+
 ## 9
 
 Add `trait_object`, which represents constant trait objects such as `const X:

--- a/doc/mir-json-schema.ts
+++ b/doc/mir-json-schema.ts
@@ -170,7 +170,8 @@ type FloatKind = { kind: "F32" | "F64" }
 
 type Layout = {
   align: number,
-  size: number
+  size: number,
+  field_offsets?: number[]
 }
 
 

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -1,3 +1,4 @@
+use rustc_abi::FieldsShape;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_hashes::Hash64;
 use rustc_hir as hir;
@@ -647,12 +648,31 @@ impl<'tcx> ToJson<'tcx> for ty::Ty<'tcx> {
                 let layout = tcx
                     .layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(*self))
                     .unwrap_or_else(|e| panic!("failed to get layout of {:?}: {}", self, e));
+                let field_offsets = match layout.fields {
+                    // `FieldsShape::Primitive` has no fields.
+                    FieldsShape::Primitive => None,
+                    // `FieldsShape::Union` puts all fields at offset zero.
+                    FieldsShape::Union(_) => None,
+                    // `FieldsShape::Array` is used only for array-like types, for which offsets
+                    // are easy to compute if needed.
+                    FieldsShape::Array { .. } => {
+                        assert!(matches!(self.kind(),
+                                ty::TyKind::Array(..) | ty::TyKind::Slice(..) | ty::TyKind::Str),
+                            "unexpected TyKind {:?} for FieldsShape::Array", self.kind());
+                        None
+                    },
+                    FieldsShape::Arbitrary { ref offsets, .. } => {
+                        Some(offsets.iter().map(|&off| off.bytes()).collect::<Vec<_>>())
+                    },
+                };
                 if layout.is_sized() {
                     Some(json!({
                         "align": layout.align.abi.bytes(),
-                        "size": layout.size.bytes()
+                        "size": layout.size.bytes(),
+                        "field_offsets": field_offsets
                     }))
                 } else {
+                    // TODO: provide field offsets even for unsized types
                     None
                 }
             }

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -638,25 +638,20 @@ impl<'tcx> ToJson<'tcx> for ty::Ty<'tcx> {
         };
 
         // Get layout information.
-        let layout_j =
-          match self.kind() {
+        let layout_j = match self.kind() {
             // `CoroutineWitness` should not appear in actual code, so we
             // can't compute their layout---and we don't need it---so we just
             // skip it.
             &ty::TyKind::CoroutineWitness(_,_) => None,
             _ => {
-              let layout = tcx
-                .layout_of(
-                    ty::TypingEnv::fully_monomorphized().as_query_input(*self)
-                )
-                .unwrap_or_else(|e| {
-                    panic!("failed to get layout of {:?}: {}", self, e)
-                });
+                let layout = tcx
+                    .layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(*self))
+                    .unwrap_or_else(|e| panic!("failed to get layout of {:?}: {}", self, e));
                 if layout.is_sized() {
                     Some(json!({
                         "align": layout.align.abi.bytes(),
                         "size": layout.size.bytes()
-                }))
+                    }))
                 } else {
                     None
                 }

--- a/src/schema_ver.rs
+++ b/src/schema_ver.rs
@@ -6,4 +6,4 @@
 /// Each version of the schema is assumed to be backwards-incompatible with
 /// previous versions of the schema. As such, any time this version number is
 /// bumped, it should be treated as a major version bump.
-pub const SCHEMA_VER: u64 = 9;
+pub const SCHEMA_VER: u64 = 10;


### PR DESCRIPTION
Output looks like this:

```jsonc
  {
    "kind": "ty",
    "data": {
      "layout": {
        "align": 4,
        "field_offsets": [    // <-- new
          0,
          4
        ],
        "size": 8
      },
      "name": "ty::Tuple::23d21b33719c9a05",
      "needs_drop": false,
      "ty": {
        "kind": "Tuple",
        "tys": [
          "ty::u16",
          "ty::u32"
        ]
      }
    }
  }
```

This branch adds field offsets only for sized types, which should be sufficient for implementing realistic layouts for tuples in crucible-mir.  For migrating structs to `MirAggregateRepr`, we'll need field offsets and possibly some additional info in order to support unsized structs; I figure we can wait to add that until it's clearer what exactly we need.

I'll wait to merge this until I have a matching crucible-mir PR ready to go.