### PR TITLE
`libs`: More patches for `Arc` and `Rc`

### DIFF
--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -90,6 +90,13 @@ into the main commit for that patch, and then the *Update* line can be removed.
   functions to call built-in Crucible allocation functions instead (e.g.
   `crucible::alloc::allocate`).
 
+* Define `Arc`/`Rc` constructors in terms of `{Arc,Rc}::new` (last applied: January 20, 2026)
+
+  This ensures that all `Arc`/`Rc` constructors are defined in terms of
+  `Box::new`, which uses Crucible's typed allocator instead of Rust's untyped
+  allocator. (See the `` Use crucible's allocator in `Box` constructors ``
+  patch above.)
+
 * Don't deallocate in `Box::drop` (last applied: November 17, 2025)
 
   Crucible doesn't support a `deallocate` operation.

--- a/libs/alloc/src/rc.rs
+++ b/libs/alloc/src/rc.rs
@@ -497,13 +497,7 @@ impl<T> Rc<T> {
     #[stable(feature = "new_uninit", since = "1.82.0")]
     #[must_use]
     pub fn new_uninit() -> Rc<mem::MaybeUninit<T>> {
-        unsafe {
-            Rc::from_ptr(Rc::allocate_for_layout(
-                Layout::new::<T>(),
-                |layout| Global.allocate(layout),
-                <*mut u8>::cast,
-            ))
-        }
+        Rc::new(mem::MaybeUninit::uninit())
     }
 
     /// Constructs a new `Rc` with uninitialized contents, with the memory
@@ -530,13 +524,7 @@ impl<T> Rc<T> {
     #[unstable(feature = "new_zeroed_alloc", issue = "129396")]
     #[must_use]
     pub fn new_zeroed() -> Rc<mem::MaybeUninit<T>> {
-        unsafe {
-            Rc::from_ptr(Rc::allocate_for_layout(
-                Layout::new::<T>(),
-                |layout| Global.allocate_zeroed(layout),
-                <*mut u8>::cast,
-            ))
-        }
+        Rc::new(mem::MaybeUninit::zeroed())
     }
 
     /// Constructs a new `Rc<T>`, returning an error if the allocation fails
@@ -591,13 +579,7 @@ impl<T> Rc<T> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     // #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn try_new_uninit() -> Result<Rc<mem::MaybeUninit<T>>, AllocError> {
-        unsafe {
-            Ok(Rc::from_ptr(Rc::try_allocate_for_layout(
-                Layout::new::<T>(),
-                |layout| Global.allocate(layout),
-                <*mut u8>::cast,
-            )?))
-        }
+        Rc::try_new(mem::MaybeUninit::uninit())
     }
 
     /// Constructs a new `Rc` with uninitialized contents, with the memory
@@ -624,13 +606,7 @@ impl<T> Rc<T> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     //#[unstable(feature = "new_uninit", issue = "63291")]
     pub fn try_new_zeroed() -> Result<Rc<mem::MaybeUninit<T>>, AllocError> {
-        unsafe {
-            Ok(Rc::from_ptr(Rc::try_allocate_for_layout(
-                Layout::new::<T>(),
-                |layout| Global.allocate_zeroed(layout),
-                <*mut u8>::cast,
-            )?))
-        }
+        Rc::try_new(mem::MaybeUninit::zeroed())
     }
     /// Constructs a new `Pin<Rc<T>>`. If `T` does not implement `Unpin`, then
     /// `value` will be pinned in memory and unable to be moved.

--- a/libs/alloc/src/sync.rs
+++ b/libs/alloc/src/sync.rs
@@ -498,13 +498,7 @@ impl<T> Arc<T> {
     #[stable(feature = "new_uninit", since = "1.82.0")]
     #[must_use]
     pub fn new_uninit() -> Arc<mem::MaybeUninit<T>> {
-        unsafe {
-            Arc::from_ptr(Arc::allocate_for_layout(
-                Layout::new::<T>(),
-                |layout| Global.allocate(layout),
-                <*mut u8>::cast,
-            ))
-        }
+        Arc::new(mem::MaybeUninit::uninit())
     }
 
     /// Constructs a new `Arc` with uninitialized contents, with the memory
@@ -532,13 +526,7 @@ impl<T> Arc<T> {
     #[unstable(feature = "new_zeroed_alloc", issue = "129396")]
     #[must_use]
     pub fn new_zeroed() -> Arc<mem::MaybeUninit<T>> {
-        unsafe {
-            Arc::from_ptr(Arc::allocate_for_layout(
-                Layout::new::<T>(),
-                |layout| Global.allocate_zeroed(layout),
-                <*mut u8>::cast,
-            ))
-        }
+        Arc::new(mem::MaybeUninit::zeroed())
     }
 
     /// Constructs a new `Pin<Arc<T>>`. If `T` does not implement `Unpin`, then
@@ -605,13 +593,7 @@ impl<T> Arc<T> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     // #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn try_new_uninit() -> Result<Arc<mem::MaybeUninit<T>>, AllocError> {
-        unsafe {
-            Ok(Arc::from_ptr(Arc::try_allocate_for_layout(
-                Layout::new::<T>(),
-                |layout| Global.allocate(layout),
-                <*mut u8>::cast,
-            )?))
-        }
+        Arc::try_new(mem::MaybeUninit::uninit())
     }
 
     /// Constructs a new `Arc` with uninitialized contents, with the memory
@@ -638,13 +620,7 @@ impl<T> Arc<T> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     // #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn try_new_zeroed() -> Result<Arc<mem::MaybeUninit<T>>, AllocError> {
-        unsafe {
-            Ok(Arc::from_ptr(Arc::try_allocate_for_layout(
-                Layout::new::<T>(),
-                |layout| Global.allocate_zeroed(layout),
-                <*mut u8>::cast,
-            )?))
-        }
+        Arc::try_new(mem::MaybeUninit::zeroed())
     }
 }
 


### PR DESCRIPTION
This is a collection of two patches related to `Arc` and `Rc`:

## `libs`: Don't deallocate in `Rc::drop` and friends

Crucible doesn't support a `deallocate` operation. We already patch out deallocations in `Arc::drop` and friends, and this commit extends the same treatment to `Rc::drop` and friends.

Fixes https://github.com/GaloisInc/mir-json/issues/220.

## `libs`: Patch `Arc`/`Rc` constructors to use `Box::new`

This avoids calling Rust's untyped allocator, which `crucible-mir` does not support.

Fixes https://github.com/GaloisInc/mir-json/issues/219.