### PR TITLE
`coroutine_args`: Normalize away associated types

### DIFF
--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -671,7 +671,11 @@ pub fn coroutine_args<'tcx>(
     let tcx = mir.tcx;
     let co_args = args.as_coroutine();
     let co_layout = tcx.coroutine_layout(defid, args).unwrap();
-    let co_layout = ty::EarlyBinder::bind(co_layout.clone()).instantiate(tcx, args);
+    let co_layout = tcx.instantiate_and_normalize_erasing_regions(
+        args,
+        ty::TypingEnv::fully_monomorphized(),
+        ty::EarlyBinder::bind(co_layout.clone()),
+    );
     json!({
         // Discriminant, upvar, and saved-local types
         "discr_ty": co_args.discr_ty(tcx).to_json(mir),

--- a/tests/issues/test0222/README.md
+++ b/tests/issues/test0222/README.md
@@ -1,0 +1,8 @@
+A regression test for [issue
+#222](https://github.com/GaloisInc/mir-json/issues/222). This ensures that
+`mir-json` properly instantiates polymorphic `async` functions and normalizes
+away any associated types that are captured by `async` closures.
+
+This test was minimized from [this
+example](https://github.com/tokio-rs/tokio/blob/8fd44d9bdc5af48c6d76aa4f3fddd45c18d0da43/examples/chat.rs)
+from the `tokio` repository, which is under the MIT license.

--- a/tests/issues/test0222/test.rs
+++ b/tests/issues/test0222/test.rs
@@ -1,0 +1,38 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pub struct TcpListener;
+
+impl TcpListener {
+    pub async fn bind<A: ToSocketAddrs>(addr: A) {
+        addr.to_socket_addrs().await;
+    }
+}
+
+pub struct MaybeReady;
+impl Future for MaybeReady {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Ready(())
+    }
+}
+
+pub trait ToSocketAddrs {
+    type Fut: Future;
+
+    fn to_socket_addrs(&self) -> Self::Fut;
+}
+
+impl ToSocketAddrs for &str {
+    type Fut = MaybeReady;
+
+    fn to_socket_addrs(&self) -> Self::Fut {
+        MaybeReady
+    }
+}
+
+pub async fn main() {
+    TcpListener::bind("127.0.0.1:6142").await
+}

--- a/tests/issues/test0222/test.sh
+++ b/tests/issues/test0222/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/../../common.sh"
+
+expect_no_panic \
+  saw-rustc --edition=2021 test.rs \
+    --target "$(rustc --print host-tuple)"


### PR DESCRIPTION
`coroutine_args` was instantiating polymorphic types in `async` functions, but it was not taking the extra step of normalizing associated types. Thankfully, doing this extra step is as easy as swapping out a single `rustc` API function.

Fixes #222.