### PR TITLE
`libs`: Replace raw pointer cast in `std::hash`

### DIFF
--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -238,6 +238,13 @@ into the main commit for that patch, and then the *Update* line can be removed.
   This feature was using an `AtomicPtr<()>` with a cast from function
   pointer to `*mut ()` that we don't support in its initializer.
 
+* Replace raw pointer cast in `std::hash` (last applied: January 22, 2026)
+
+  Crucible doesn't currently support casting a `*mut u32` pointer to a `*mut
+  u8` and then trying to write `u8` values into it. We instead rewrite the code
+  slightly such that we build a `&mut [u8]` slice and then cast it to a `*mut
+  u8`, thereby avoiding the need for `u32` altogether.
+
 # Notes
 
 This section contains more detailed notes about why certain patches are written

--- a/libs/core/src/hash/sip.rs
+++ b/libs/core/src/hash/sip.rs
@@ -100,13 +100,13 @@ macro_rules! compress {
 macro_rules! load_int_le {
     ($buf:expr, $i:expr, $int_ty:ident) => {{
         debug_assert!($i + size_of::<$int_ty>() <= $buf.len());
-        let mut data = 0 as $int_ty;
+        let mut data = [0u8; size_of::<$int_ty>()];
         ptr::copy_nonoverlapping(
             $buf.as_ptr().add($i),
-            &mut data as *mut _ as *mut u8,
+            data.as_mut_slice().as_mut_ptr(),
             size_of::<$int_ty>(),
         );
-        data.to_le()
+        <$int_ty>::from_ne_bytes(data).to_le()
     }};
 }
 


### PR DESCRIPTION
Fixes #228.