### PR TITLE
`libs`: Avoid raw pointer comparisons in `std::thread`

### DIFF
--- a/libs/std/src/thread/current.rs
+++ b/libs/std/src/thread/current.rs
@@ -169,7 +169,7 @@ where
     F: FnOnce(Option<&Thread>) -> R,
 {
     let current = CURRENT.get();
-    if current > DESTROYED {
+    if current != NONE && current != BUSY && current != DESTROYED {
         // SAFETY: `Arc` does not contain interior mutability, so it does not
         // matter that the address of the handle might be different depending
         // on where this is called.
@@ -187,7 +187,7 @@ where
 /// handle to allow thread parking in nearly all situations.
 pub(crate) fn current_or_unnamed() -> Thread {
     let current = CURRENT.get();
-    if current > DESTROYED {
+    if current != NONE && current != BUSY && current != DESTROYED {
         unsafe {
             let current = ManuallyDrop::new(Thread::from_raw(current));
             (*current).clone()
@@ -222,7 +222,7 @@ pub(crate) fn current_or_unnamed() -> Thread {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn current() -> Thread {
     let current = CURRENT.get();
-    if current > DESTROYED {
+    if current != NONE && current != BUSY && current != DESTROYED {
         unsafe {
             let current = ManuallyDrop::new(Thread::from_raw(current));
             (*current).clone()
@@ -279,7 +279,7 @@ fn init_current(current: *mut ()) -> Thread {
 /// handle.
 pub(crate) fn drop_current() {
     let current = CURRENT.get();
-    if current > DESTROYED {
+    if current != NONE && current != BUSY && current != DESTROYED {
         unsafe {
             CURRENT.set(DESTROYED);
             drop(Thread::from_raw(current));


### PR DESCRIPTION
Fixes #225.