### PR TITLE
libs fixes for tokio

### DIFF
--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -325,6 +325,14 @@ into the main commit for that patch, and then the *Update* line can be removed.
   currently support this usage of `union`s. This patch replaces the `union`
   with an equivalent `enum`.
 
+* Use `list` TLS destructors instead of `linux_like` (last applied April 22, 2026)
+
+  The `std::sys::thread_local::destructors::linux_like` module calls into some
+  low-level extern symbols like `__cxa_thread_atexit_impl`, which we don't
+  support.  This causes errors when initializing a `thread_local!` variable in
+  some cases.  The alternative `destructors::list` implementation is simpler
+  and is defined in terms of things we already support (`Vec` and `RefCell`).
+
 # Notes
 
 This section contains more detailed notes about why certain patches are written

--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -333,6 +333,13 @@ into the main commit for that patch, and then the *Update* line can be removed.
   some cases.  The alternative `destructors::list` implementation is simpler
   and is defined in terms of things we already support (`Vec` and `RefCell`).
 
+* Use `memchr_naive` for all `memchr` variants (last applied April 22, 2026)
+
+  The optimized implementation tries to load an entire `usize` at a time
+  instead of going byte by byte, but crucible-mir doesn't support this sort of
+  transmuting load.  The naive version is equivalent (according to comments in
+  that file) and should be much simpler to simulate.
+
 # Notes
 
 This section contains more detailed notes about why certain patches are written

--- a/libs/core/src/slice/memchr.rs
+++ b/libs/core/src/slice/memchr.rs
@@ -47,63 +47,8 @@ const fn memchr_naive(x: u8, text: &[u8]) -> Option<usize> {
     None
 }
 
-#[rustc_allow_const_fn_unstable(const_eval_select)] // fallback impl has same behavior
 const fn memchr_aligned(x: u8, text: &[u8]) -> Option<usize> {
-    // The runtime version behaves the same as the compiletime version, it's
-    // just more optimized.
-    const_eval_select!(
-        @capture { x: u8, text: &[u8] } -> Option<usize>:
-        if const {
-            memchr_naive(x, text)
-        } else {
-            // Scan for a single byte value by reading two `usize` words at a time.
-            //
-            // Split `text` in three parts
-            // - unaligned initial part, before the first word aligned address in text
-            // - body, scan by 2 words at a time
-            // - the last remaining part, < 2 word size
-
-            // search up to an aligned boundary
-            let len = text.len();
-            let ptr = text.as_ptr();
-            let mut offset = ptr.align_offset(USIZE_BYTES);
-
-            if offset > 0 {
-                offset = offset.min(len);
-                let slice = &text[..offset];
-                if let Some(index) = memchr_naive(x, slice) {
-                    return Some(index);
-                }
-            }
-
-            // search the body of the text
-            let repeated_x = usize::repeat_u8(x);
-            while offset <= len - 2 * USIZE_BYTES {
-                // SAFETY: the while's predicate guarantees a distance of at least 2 * usize_bytes
-                // between the offset and the end of the slice.
-                unsafe {
-                    let u = *(ptr.add(offset) as *const usize);
-                    let v = *(ptr.add(offset + USIZE_BYTES) as *const usize);
-
-                    // break if there is a matching byte
-                    let zu = contains_zero_byte(u ^ repeated_x);
-                    let zv = contains_zero_byte(v ^ repeated_x);
-                    if zu || zv {
-                        break;
-                    }
-                }
-                offset += USIZE_BYTES * 2;
-            }
-
-            // Find the byte after the point the body loop stopped.
-            // FIXME(const-hack): Use `?` instead.
-            // FIXME(const-hack, fee1-dead): use range slicing
-            let slice =
-            // SAFETY: offset is within bounds
-                unsafe { super::from_raw_parts(text.as_ptr().add(offset), text.len() - offset) };
-            if let Some(i) = memchr_naive(x, slice) { Some(offset + i) } else { None }
-        }
-    )
+    memchr_naive(x, text)
 }
 
 /// Returns the last index matching the byte `x` in `text`.

--- a/libs/std/src/sys/thread_local/mod.rs
+++ b/libs/std/src/sys/thread_local/mod.rs
@@ -55,27 +55,9 @@ cfg_select! {
 /// single callback that runs all of the destructors in the list.
 #[cfg(all(target_thread_local, not(all(target_family = "wasm", not(target_feature = "atomics")))))]
 pub(crate) mod destructors {
-    cfg_select! {
-        any(
-            target_os = "linux",
-            target_os = "android",
-            target_os = "fuchsia",
-            target_os = "redox",
-            target_os = "hurd",
-            target_os = "netbsd",
-            target_os = "dragonfly"
-        ) => {
-            mod linux_like;
-            mod list;
-            pub(super) use linux_like::register;
-            pub(super) use list::run;
-        }
-        _ => {
-            mod list;
-            pub(super) use list::register;
-            pub(crate) use list::run;
-        }
-    }
+    mod list;
+    pub(super) use list::register;
+    pub(crate) use list::run;
 }
 
 /// This module provides a way to schedule the execution of the destructor list


### PR DESCRIPTION
* Always use `std::sys::thread_local::destructors::list`, which is simpler than `destructors::linux_like`
* Replace all variants of `core::slice::memchr::memchr` with `memchr_naive`

The destructor change let me get a trivial tokio example running on Linux:
```Rust
pub async fn add_two_randoms() -> u32 {
    let x = get_random(1, 5).await;
    let y = get_random(2, 6).await;
    x + y
}

async fn get_random(lo: u32, hi: u32) -> u32 {
    lo
}

#[cfg(crux)]
mod verification {
    use super::*;

    /// Verify that add_two_randoms produces a number in range
    #[crux::test]
    fn add_two_randoms_spec() {
        let runtime = tokio::runtime::Builder::new_current_thread().build().unwrap();
        runtime.block_on(add_two_randoms());
        std::mem::forget(runtime);
    }
}
```

The `mem::forget` is needed for now since there's some thread park/unpark logic in the runtime's destructor that crux-mir can't handle.

The switch to `memchr_naive` fixes an issue that (IIRC) @glguy ran into while testing a similar example on MacOS.  I didn't see that particular error from tokio when I was testing on Linux, but I can confirm that the change causes `CStr::from_bytes_with_nul(b"long string bigger than two words\0")` to succeed where it previously failed.  (`len >= 2 * size_of::<usize>()` is the cutoff for switching to the optimized `memchr` implementation that was causing problems for crux-mir.)