### PR TITLE
add size and align to vtables (schema ver 11)

### DIFF
--- a/SCHEMA_CHANGELOG.md
+++ b/SCHEMA_CHANGELOG.md
@@ -3,6 +3,10 @@ The following document describes the changes to the JSON schema that
 as a changelog for the code in the `mir-json` tools themselves, which are
 versioned separately.)
 
+## 11
+
+Add `size` and `align` fields to `dyn Trait` vtables.
+
 ## 10
 
 Add field offsets to the layout information for struct-like types.  This is

--- a/doc/mir-json-schema.ts
+++ b/doc/mir-json-schema.ts
@@ -198,7 +198,9 @@ type Static = {
 type Vtable = {
   name : DefId,
   items: VtableItem[],
-  trait_id: DefId
+  trait_id: DefId,
+  size: number,
+  align: number
 }
 
 type VtableItem = {

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -1187,10 +1187,22 @@ fn emit_vtable<'tcx>(
 ) -> io::Result<()> {
     let trait_ref = ms.tcx.instantiate_bound_regions_with_erased(poly_trait_ref);
     let ti = TraitInst::from_trait_ref(ms.tcx, trait_ref);
+
+    // Get size and align of the `Self` type.  The `size` stored in the vtable is used for
+    // `size_of_val`.  The `align` is used for `align_of_val`, and also determines the offset when
+    // this `dyn` type appears as the unsized tail (last field) of a custom DST.
+    let ty = trait_ref.self_ty();
+    let layout = ms.tcx
+        .layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(ty))
+        .unwrap_or_else(|e| panic!("failed to get layout of {:?}: {}", ty, e));
+    assert!(layout.is_sized(), "casting an unsized type to `dyn` should be forbidden by rustc");
+
     out.emit(EntryKind::Vtable, json!({
         "trait_id": trait_inst_id_str(ms.tcx, &ti),
         "name": vtable_name(ms, poly_trait_ref),
         "items": build_vtable_items(ms, poly_trait_ref),
+        "size": layout.size.bytes(),
+        "align": layout.align.abi.bytes(),
     }))?;
     emit_new_defs(ms, out)
 }

--- a/src/schema_ver.rs
+++ b/src/schema_ver.rs
@@ -6,4 +6,4 @@
 /// Each version of the schema is assumed to be backwards-incompatible with
 /// previous versions of the schema. As such, any time this version number is
 /// bumped, it should be treated as a major version bump.
-pub const SCHEMA_VER: u64 = 10;
+pub const SCHEMA_VER: u64 = 11;


### PR DESCRIPTION
Adds `size` and `align` fields to vtable definitions.  These fields are non-optional, since only sized types can be coerced to `&dyn Trait`.  These will initially be used in crucible-mir to implement the `dyn` cases of `size_of_val` and `align_of_val`.

Longer term, the motivation for adding this is that the vtable alignment is needed when representing structs with `MirAggregateRepr`.  In `CustomDST<dyn Trait>`, the offset of the last field depends on its alignment, and its alignment is always the alignment of the erased type.  So computing the offset of the last field requires fetching the alignment from the vtable.

Currently the output JSON doesn't contain any link from a vtable to its `Self` type, since nothing needs it currently.  It seemed easier to add the size and align fields directly to the vtable, rather than adding a reference to a `Ty` that we otherwise wouldn't use.