### PR TITLE
ty_json: include shim_kind in Unsupported instance emissions

### DIFF
--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -455,21 +455,27 @@ impl<'tcx> ToJson<'tcx> for ty::Instance<'tcx> {
             },
             ty::InstanceKind::ConstructCoroutineInClosureShim { .. } => json!({
                 "kind": "Unsupported",
+                "shim_kind": "ConstructCoroutineInClosureShim",
             }),
             ty::InstanceKind::ThreadLocalShim(_def_id) => json!({
                 "kind": "Unsupported",
+                "shim_kind": "ThreadLocalShim",
             }),
             ty::InstanceKind::FutureDropPollShim(_def_id, _proxy_cor_ty, _impl_cor_ty) => json!({
                 "kind": "Unsupported",
+                "shim_kind": "FutureDropPollShim",
             }),
             ty::InstanceKind::FnPtrAddrShim(_def_id, _ty) => json!({
                 "kind": "Unsupported",
+                "shim_kind": "FnPtrAddrShim",
             }),
             ty::InstanceKind::AsyncDropGlueCtorShim(_def_id, _ty) => json!({
                 "kind": "Unsupported",
+                "shim_kind": "AsyncDropGlueCtorShim",
             }),
             ty::InstanceKind::AsyncDropGlue(_def_id, _ty) => json!({
                 "kind": "Unsupported",
+                "shim_kind": "AsyncDropGlue",
             }),
         }
     }


### PR DESCRIPTION
## Problem

Today `mir-json` emits `{"kind": "Unsupported"}` for six instance variants it does not yet model:

- `ConstructCoroutineInClosureShim`
- `ThreadLocalShim`
- `FutureDropPollShim`
- `FnPtrAddrShim`
- `AsyncDropGlueCtorShim`
- `AsyncDropGlue`

Downstream consumers (crucible-mir) cannot tell *which* shim was elided. If one of these shims is actually called during verification, the only diagnostic the user gets is "shim was Unsupported" — they can't tell whether the problem is an async drop glue, a thread-local, or something else, and each of those has a completely different workaround.

## Background

[Issue #199](https://github.com/GaloisInc/mir-json/issues/199) (filed by @RyanGlScott in Dec 2025) originally asked for distinct JSON tags on the shim variants as well as on the coroutine type constructors. That issue was marked complete after PRs #205 / #214 added proper tags for the *type-level* `Coroutine` / `CoroutineClosure` constructors, but the six `InstanceKind::*Shim` variants listed above were left emitting plain `{"kind": "Unsupported"}`. This PR finishes that work.

## Fix

Include a `shim_kind` field in each `Unsupported` JSON emission, naming the original `InstanceKind` variant. Purely additive: older crucible-mir versions that don't read `shim_kind` simply ignore it.

The tag itself has no semantic effect — it's purely for error-message quality at the point a shim is actually invoked. Without it, a user whose verified function transitively reaches one of these shims sees "Cannot call unsupported shim" with no indication of which kind, leaving them to guess between six unrelated workarounds. With it, the deferred error can name the specific shim ("Cannot call `AsyncDropGlue` shim …"), which is searchable, actionable, and reportable.

## Diff

```
src/analyz/ty_json.rs | 6 ++++++
1 file changed, 6 insertions(+)
```

## Companion PR

- [GaloisInc/crucible#1840](https://github.com/GaloisInc/crucible/pull/1840) — accepts the new `shim_kind` field on the crucible-mir side and uses it for clearer error messages if an `IkUnsupported` instance is ever called. (That PR also makes `mir_load_module` tolerant of `"Unsupported"` instead of failing the whole module load — which is what currently blocks SAW from running on any crate whose dependency graph touches async, thread-locals, or function-pointer addressing.)

Filed as draft for upstream review.