### PR TITLE
`dependabot.yml`: Don't automatically update `cargo` dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # mir-json's implementation is tightly coupled to the cargo API, which
+      # means that it is generally not possible to update to newer versions of
+      # cargo automatically.
+      - dependency-name: "cargo"


### PR DESCRIPTION
As seen in https://github.com/GaloisInc/mir-json/pull/278, we generally cannot update the `cargo` dependency automatically, as the code in `mir-json` is tightly coupled to `cargo`'s API. Tell dependabot not to even bother trying.