### PR TITLE
`dependabot.yml`: Don't suggest major updates to `cargo` dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      # mir-json's implementation is tightly coupled to the cargo API, which
-      # means that it is generally not possible to update to newer versions of
-      # cargo automatically.
-      - dependency-name: "cargo"
+      # Only propose minor or patch updates to cargo dependencies, as these are
+      # much more likely to be backwards-compatible than major updates.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Previously, we just ruled out updates to the `cargo` crate, but this wasn't enough: there are other dependencies to which `mir-json` is tightly coupled, both `cargo`-related (e.g., see https://github.com/GaloisInc/mir-json/pull/282), and non-`cargo`-related (e.g., see https://github.com/GaloisInc/mir-json/pull/283). Exhaustively listing them all would prove to be a pain in the neck.

Instead, let's just instruct dependabot to only recommend automated updates for minor and patch releases. These are far more likely to work out of the box with `mir-json`'s code than major updates.