### PR TITLE
Add a command-line tool for managing 'mir-json' installations.

### DIFF
--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+set -e
+
+require_tool() {
+    local TOOL_EXEC="$1"
+    local TOOL_NAME="$2"
+    set +e
+    TOOL_PATH=$(which "${TOOL_EXEC}")
+    set -e
+    if [[ "$?" != 0 ]]; then
+        echo "This script requires ${TOOL_NAME}"
+        exit 1
+    fi
+}
+
+require_rust_component() {
+    local COMPONENT_NAME="$1"
+    if [[ $(rustup component list --toolchain "${MIR_JSON_RUST_TOOLCHAIN}" --installed | grep -c "^${COMPONENT_NAME}") == 0 ]]; then
+        echo "Building mir-json requires the Rust component ${COMPONENT_NAME}; install it with"
+        echo "  rustup component add --toolchain \"${MIR_JSON_RUST_TOOLCHAIN}\" ${COMPONENT_NAME}"
+        exit 1
+    fi
+}
+
+# Need 'git' to download 'mir-json', 'cc' to run the compiler,
+# and 'rustup' to handle Rust dependencies.
+check_tools() {
+    require_tool cc "a C compiler"
+    require_tool git "Git"
+    require_tool rustup "Rustup"
+}
+
+check_rust_toolchain() {
+    if [[ $(rustup toolchain list | grep "${MIR_JSON_RUST_TOOLCHAIN}") == "" ]]; then
+        echo "Building mir-json requires the Rust toolchain ${MIR_JSON_RUST_TOOLCHAIN}; install it with"
+        echo "  rustup toolchain install ${MIR_JSON_RUST_TOOLCHAIN}"
+        exit 1
+    fi
+}
+
+get_toolchain_dir() {
+    local TOOLCHAIN="${1:-${MIR_JSON_RUST_TOOLCHAIN}}"
+    local TARGET="${2:-${TARGET_TRIPLET}}"
+    echo "${MIR_JSON_INSTALL_DIR}/toolchains/${TOOLCHAIN}/${TARGET}"
+}
+
+get_mir_json_src() {
+    local MIR_JSON_SRC_DIR="$(get_toolchain_dir)/src"
+    mkdir -p "${MIR_JSON_SRC_DIR}"
+    cd "${MIR_JSON_SRC_DIR}"
+    if ! [[ -d mir-json ]]; then
+        git clone https://github.com/GaloisInc/mir-json.git
+    fi
+}
+
+build_mir_json() {
+    local MIR_JSON_SRC_DIR="$(get_toolchain_dir)/src"
+    local MIR_JSON_BIN_DIR="$(get_toolchain_dir)/bin"
+    local MIR_JSON_RLIBS_DIR="$(get_toolchain_dir)/rlibs"
+    mkdir -p "${MIR_JSON_BIN_DIR}"
+    cd "${MIR_JSON_SRC_DIR}/mir-json"
+    cargo +"${MIR_JSON_RUST_TOOLCHAIN}" build -r --target-dir "${MIR_JSON_BIN_DIR}" --locked
+    PATH="${MIR_JSON_BIN_DIR}/release:$PATH"
+    echo $PATH
+    mir-json-translate-libs
+    if [[ $? == 0 ]]; then
+        if [[ -e "${MIR_JSON_RLIBS_DIR}" ]]; then
+            rm -rfv "${MIR_JSON_RLIBS_DIR}"
+        fi
+        cp -RL rlibs "${MIR_JSON_RLIBS_DIR}"
+    fi
+}
+
+check_all_prerequisites() {
+    check_tools
+
+    MIR_JSON_INSTALL_DIR=${MIR_JSON_INSTALL_DIR:-~/.mir-json-up}
+    MIR_JSON_RUST_TOOLCHAIN=${MIR_JSON_RUST_TOOLCHAIN:-nightly-2025-09-14}
+    TARGET_TRIPLET=${TARGET_TRIPLET:-$(cc -dumpmachine)}
+
+    check_rust_toolchain
+
+    require_rust_component rust-src
+    require_rust_component rustc-dev
+}
+
+build_env() {
+    local TOOLCHAIN_DIR=$(get_toolchain_dir)
+    cat <<EOF >> "${MIR_JSON_INSTALL_DIR}/env"
+#!/bin/sh
+case ":\${PATH}:" in
+   *:"${TOOLCHAIN_DIR}/bin/release":*)
+       ;;
+   *)
+       export PATH="${TOOLCHAIN_DIR}/bin/release:$PATH"
+esac
+export CRUX_RUST_LIBRARY_PATH="${TOOLCHAIN_DIR}/rlibs"
+EOF
+}
+
+COMMAND="$1"
+shift 1
+
+case "$COMMAND" in
+    check)
+        check_all_prerequisites
+        echo "All prerequisites in place"
+        echo "  Rust toolchain: $MIR_JSON_RUST_TOOLCHAIN"
+        echo "  Installing into: $MIR_JSON_INSTALL_DIR"
+        echo "  Target: $TARGET_TRIPLET"
+        ;;
+    build)
+        check_all_prerequisites
+        get_mir_json_src
+        build_mir_json
+        build_env
+        echo "Successfully built mir-json"
+        echo "To configure the current shell, run . ${MIR_JSON_INSTALL_DIR}/env"
+        ;;
+    run)
+        check_all_prerequisites
+        if [[ ! -e "${MIR_JSON_INSTALL_DIR}/env" ]]; then
+            echo "Cannot run before building: ${MIR_JSON_INSTALL_DIR}/env does not exist"
+            exit 1
+        fi
+        . "${MIR_JSON_INSTALL_DIR}/env"
+        $@
+        ;;
+    *)
+        echo "Invalid command: ${COMMAND}"
+        exit 1
+        ;;
+esac
+

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -41,8 +41,10 @@ require_rust_component() {
     fi
 }
 
-# Need 'git' to download 'mir-json', 'cc' to run the compiler,
-# and 'rustup' to handle Rust dependencies.
+# Need 'git' to download 'mir-json', 'cc' to run the compiler
+# (the 'mir-json' build will fail for lack of a linker if a
+# C compiler is not installed), and 'rustup' to handle Rust
+# dependencies.
 check_tools() {
     require_tool cc "a C compiler"
     require_tool git "Git"

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -136,6 +136,7 @@ target_triplet_from_cc() {
            ;;
         arm64-apple-darwin*)
            echo "aarch64-apple-darwin"
+           ;;
         *)
            echo "$TRIPLET"
     esac    

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -221,11 +221,11 @@ check_general_prerequisites() {
        if [[ $INITIALIZE_IF_MISSING == 0 ]]; then
             echo "Checking out source repository for mir-json ${MIR_JSON_VERSION}" 1>&2
             get_mir_json_src "${MIR_JSON_VERSION}"
+            if [[ ! -d "$(get_mir_json_src_dir ${MIR_JSON_VERSION})" ]]; then
+                echo "mir-json ${MIR_JSON_VERSION} failed to check out" 1>&2
+                exit 1
+            fi
        fi
-        if [[ ! -d "$(get_mir_json_src_dir ${MIR_JSON_VERSION})" ]]; then
-            echo "mir-json ${MIR_JSON_VERSION} failed to check out" 1>&2
-            exit 1
-        fi
     else
         if [[ ! -d "$(get_mir_json_src_dir ${MIR_JSON_VERSION})" ]]; then
             echo "mir-json ${MIR_JSON_VERSION} not checked out" 1>&2
@@ -398,8 +398,11 @@ case "$COMMAND" in
             echo "${MIR_JSON_INSTALL_DIR} does not exist" 1>&2
             exit 1
         fi
+        if [[ ! -d "${MIR_JSON_INSTALL_DIR}/toolchains" || -z $(ls -A "${MIR_JSON_INSTALL_DIR}/toolchains") ]]; then
+            exit 0
+        fi
         cd "${MIR_JSON_INSTALL_DIR}/toolchains"
-        for toolchain in $(ls -1d */*/* | grep -v "[*]/[*]/[*]"); do
+        for toolchain in $(ls -1d */*/*); do
             echo -n "$toolchain"
             if [[ -f "${MIR_JSON_INSTALL_DIR}/default/id" ]]; then
                 ACTIVE_TOOLCHAIN=$(cat "${MIR_JSON_INSTALL_DIR}/default/id")

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 
 set -e
+IFS='
+'
 
 require_tool() {
     local TOOL_EXEC="$1"
     local TOOL_NAME="$2"
     set +e
-    TOOL_PATH=$(which "${TOOL_EXEC}")
+    local TOOL_PATH=$(which "${TOOL_EXEC}")
     if [[ "$?" != 0 ]]; then
-        echo "This script requires ${TOOL_NAME}"
+        echo "This script requires ${TOOL_NAME}" 1>&2
         exit 1
     fi
     set -e
@@ -16,10 +18,14 @@ require_tool() {
 
 require_rust_toolchain() {
     local RUST_TOOLCHAIN="${1:-${MIR_JSON_RUST_TOOLCHAIN}}"
+    # If 'rustup toolchain list' is run in any directory containing
+    # a 'rust-toolchain.toml' file, it will automatically install the
+    # toolchain named therein. To prevent this, change to a directory
+    # with no 'rust-toolchain.toml' file.
     pushd "${MIR_JSON_INSTALL_DIR}" > /dev/null
     if [[ $(rustup toolchain list | grep "${RUST_TOOLCHAIN}") == "" ]]; then
-        echo "Building mir-json requires the Rust toolchain ${RUST_TOOLCHAIN}; install it with"
-        echo "  rustup toolchain install ${RUST_TOOLCHAIN}"
+        echo "Building mir-json requires the Rust toolchain ${RUST_TOOLCHAIN}; install it with" 1>&2
+        echo "  rustup toolchain install ${RUST_TOOLCHAIN}" 1>&2
         exit 1
     fi
     popd > /dev/null
@@ -29,8 +35,8 @@ require_rust_component() {
     local COMPONENT_NAME="$1"
     require_rust_toolchain "${MIR_JSON_RUST_TOOLCHAIN}"
     if [[ $(rustup component list --toolchain "${MIR_JSON_RUST_TOOLCHAIN}" --installed | grep -c "^${COMPONENT_NAME}") == 0 ]]; then
-        echo "Building mir-json requires the Rust component ${COMPONENT_NAME}; install it with"
-        echo "  rustup component add --toolchain \"${MIR_JSON_RUST_TOOLCHAIN}\" ${COMPONENT_NAME}"
+        echo "Building mir-json requires the Rust component ${COMPONENT_NAME}; install it with" 1>&2
+        echo "  rustup component add --toolchain \"${MIR_JSON_RUST_TOOLCHAIN}\" ${COMPONENT_NAME}" 1>&2
         exit 1
     fi
 }
@@ -46,8 +52,8 @@ check_tools() {
 check_rust_toolchain() {
     require_rust_toolchain "${MIR_JSON_RUST_TOOLCHAIN}"
     if [[ $(rustup target list --installed | grep "${TARGET_TRIPLET}") == "" ]]; then
-        echo "Target ${TARGET_TRIPLET} not installed; install with"
-        echo "  rustup target add ${TARGET_TRIPLET}"
+        echo "Target ${TARGET_TRIPLET} not installed; install with" 1>&2
+        echo "  rustup target add ${TARGET_TRIPLET}" 1>&2
         exit 1
     fi
 }
@@ -57,6 +63,21 @@ get_toolchain_dir() {
     local TOOLCHAIN="${2:-${MIR_JSON_RUST_TOOLCHAIN}}"
     local TARGET="${3:-${TARGET_TRIPLET}}"
     echo "${MIR_JSON_INSTALL_DIR}/toolchains/${VERSION}/${TOOLCHAIN}/${TARGET}"
+}
+
+toolchain_is_default() {
+    local TOOLCHAIN_DIR="${1:-$(get_toolchain_dir)}"
+
+    if [[ -f "${MIR_JSON_INSTALL_DIR}/default/id" ]]; then
+        ACTIVE_TOOLCHAIN=$(cat "${MIR_JSON_INSTALL_DIR}/default/id")
+        if [[ "${ACTIVE_TOOLCHAIN}" == "${TOOLCHAIN_DIR#${MIR_JSON_INSTALL_DIR}/toolchains/}" ]]; then
+            echo -n "0"
+        else
+            echo -n "1"
+        fi
+    else
+        echo -n "1"
+    fi
 }
 
 get_mir_json_src_dir() {
@@ -72,6 +93,7 @@ get_mir_json_src() {
     if ! [[ -d mir-json ]]; then
         git clone https://github.com/GaloisInc/mir-json.git
     fi
+    cp mir-json/rust-toolchain.toml .
     cd mir-json
     set +e
     if [[ $(git show-ref refs/tags/"${MIR_JSON_VERSION}") == "" ]]; then
@@ -82,13 +104,19 @@ get_mir_json_src() {
     popd > /dev/null
 }
 
+cleanup_mir_json_src() {
+    local VERSION="${1:-${MIR_JSON_VERSION}}"
+    local MIR_JSON_SRC_DIR=$(get_mir_json_src_dir "$VERSION")
+    rm -rf "${MIR_JSON_SRC_DIR}/mir-json"
+}
+
 create_installation_dir() {
     if [[ -d "${MIR_JSON_INSTALL_DIR}/default/bin" ]]; then
           rm -rf "${MIR_JSON_INSTALL_DIR}/default/bin"
     fi
     mkdir -p "${MIR_JSON_INSTALL_DIR}/default/bin"
     pushd "${MIR_JSON_INSTALL_DIR}/default/bin" > /dev/null
-    ln -s ../../mir-json-up
+    ln -s ../../mir-json-up mir-json-up
     if [[ ! -e "${MIR_JSON_INSTALL_DIR}/mir-json-up" ]]; then
          cp "${SCRIPT_FILE}" "${MIR_JSON_INSTALL_DIR}/mir-json-up"
     fi
@@ -104,10 +132,11 @@ create_default_symlinks() {
         rm -rf "${MIR_JSON_INSTALL_DIR}/default"
     fi
     create_installation_dir
-    echo "${TOOLCHAIN_DIR}" > "${MIR_JSON_INSTALL_DIR}/default/id"
+    local TOOLCHAINS_DIR="${MIR_JSON_INSTALL_DIR}/toolchains/"
+    echo -n "${TOOLCHAIN_DIR#${TOOLCHAINS_DIR}}" > "${MIR_JSON_INSTALL_DIR}/default/id"
     pushd "${MIR_JSON_INSTALL_DIR}/default/bin" > /dev/null
-    for execFile in $(find "${MIR_JSON_BIN_DIR}" -maxdepth 1 -type f); do
-        if [[ -x "${execFile}" ]]; then
+    for execFile in "${MIR_JSON_BIN_DIR}"/*; do
+        if [[ -f "${execFile}" && -x "${execFile}" ]]; then
             ln -s "${execFile}"
         fi
     done
@@ -125,13 +154,15 @@ build_mir_json() {
     cargo +"${MIR_JSON_RUST_TOOLCHAIN}" build -r --target "${TARGET_TRIPLET}" --target-dir "${MIR_JSON_BIN_DIR}" --locked
     PATH="${MIR_JSON_BIN_DIR}/${TARGET_TRIPLET}/release:$PATH"
     mir-json-translate-libs --target "${TARGET_TRIPLET}"
-    if [[ $? == 0 ]]; then
+    if [[ $? ]]; then
         if [[ -e "${MIR_JSON_RLIBS_DIR}" ]]; then
             rm -rfv "${MIR_JSON_RLIBS_DIR}"
         fi
-        cp -RL rlibs "${MIR_JSON_RLIBS_DIR}"
+        tar cf rlibs.tar rlibs
+        pushd "$(get_toolchain_dir)" > /dev/null
+        tar xf "${MIR_JSON_SRC_DIR}/mir-json/rlibs.tar"
     fi
-    if [[ ! -d "${MIR_JSON_INSTALL_DIR}/default/bin/mir-json" ]]; then
+    if [[ ! -f "${MIR_JSON_INSTALL_DIR}/default/bin/mir-json" ]]; then
         create_default_symlinks "$(get_toolchain_dir)"
     fi
     popd > /dev/null
@@ -140,11 +171,15 @@ build_mir_json() {
 get_toolchain_from_mir_json_version() {
     local VERSION="${1:-${MIR_JSON_VERSION}}"
     local MIR_JSON_SRC_DIR=$(get_mir_json_src_dir "${VERSION}")
-    echo $(cat "${MIR_JSON_SRC_DIR}/mir-json/rust-toolchain.toml" | grep "^channel = " | cut -f 2 -d '"')
+    echo $(cat "${MIR_JSON_SRC_DIR}/rust-toolchain.toml" | grep "^channel = " | cut -f 2 -d '"')
 }
 
 get_target_triplet_from_toolchain() {
     local RUST_TOOLCHAIN="${1:-${MIR_JSON_RUST_TOOLCHAIN}}"
+    # If 'rustup toolchain list' is run in any directory containing
+    # a 'rust-toolchain.toml' file, it will automatically install the
+    # toolchain named therein. To prevent this, change to a directory
+    # with no 'rust-toolchain.toml' file.
     pushd "${MIR_JSON_INSTALL_DIR}" > /dev/null
     if [[ $(rustup toolchain list | grep "${RUST_TOOLCHAIN}") != "" ]]; then
         echo $(rustc +"${RUST_TOOLCHAIN}" --print host-tuple)
@@ -162,7 +197,7 @@ check_installation_dir() {
        fi
     fi
     if [[ ! -d "${MIR_JSON_INSTALL_DIR}" ]]; then
-       echo "Install directory ${MIR_JSON_INSTALL_DIR} does not exist"
+       echo "Install directory ${MIR_JSON_INSTALL_DIR} does not exist" 1>&2
        exit 1
     fi
 }
@@ -177,12 +212,12 @@ check_general_prerequisites() {
     MIR_JSON_VERSION="${MIR_JSON_VERSION:-master}"
     if [[ ! -d "$(get_mir_json_src_dir ${MIR_JSON_VERSION})" ]]; then
        if [[ $INITIALIZE_IF_MISSING == 0 ]]; then
-            echo "Checking out source repository for mir-json ${MIR_JSON_VERSION}"
+            echo "Checking out source repository for mir-json ${MIR_JSON_VERSION}" 1>&2
             get_mir_json_src "${MIR_JSON_VERSION}"
        fi
     fi
     if [[ ! -d "$(get_mir_json_src_dir ${MIR_JSON_VERSION})" ]]; then
-        echo "mir-json ${MIR_JSON_VERSION} not checked out"
+        echo "mir-json ${MIR_JSON_VERSION} not checked out" 1>&2
         exit 1
     fi
 }
@@ -209,7 +244,7 @@ case ":\${PATH}:" in
    *:"${MIR_JSON_INSTALL_DIR}/default/bin":*)
        ;;
    *)
-       export PATH="${MIR_JSON_INSTALL_DIR}/default/bin:$PATH"
+       export PATH="${MIR_JSON_INSTALL_DIR}/default/bin:\${PATH}"
 esac
 export CRUX_RUST_LIBRARY_PATH="${MIR_JSON_INSTALL_DIR}/default/rlibs"
 EOF
@@ -218,53 +253,84 @@ EOF
 display_help() {
     case "$1" in
         run)
-            echo "Usage: mir-json-up run [--] command-line"
-            echo "   Run the given command line within the active 'mir-json' version/target combination"
+            cat 1>&2 << EOM
+Usage: mir-json-up run [--] command-line"
+Run the given command line within the active 'mir-json' version/target combination
+EOM
             ;;
         *)
-            echo "Usage: mir-json-up [--install-dir DIR] [--mir-json-version GIT-REF]"
-            echo "         [--mir-json-rust-toolchain RUST-TOOLCHAIN] [--target-triplet TRIPLET] command"
-            echo "Options:"
-            echo "   --install-dir        Directory holding the 'mir-json-up' installation"
-            echo "                            (default \$HOME/.mir-json-up)"
-            echo "   --mir-json-version   Git reference for the version of 'mir-json' to use/install"
-            echo "                            (default 'master')"
-            echo "   --mir-json-rust-toolchain     Rust toolchain to use (default 'nightly-2025-09-14')"
-            echo "   --target-triplet     Target triplet to use (default is the output of cc -dumpmachine)"
-            echo "Commands:"
-            echo "  mir-json-up check     Check if all requirements are in place for building 'mir-json'"
-            echo "  mir-json-up help      Display this help (add a command name for command-specific help)"
-            echo "  mir-json-up init      Install 'mir-json-up'"
-            echo "  mir-json-up install   Download and build a specific version of 'mir-json' for a specific target"
-            echo "  mir-json-up list      List all version/target 'mir-json' combinations installed"
-            echo "  mir-json-up remove    Remove the given 'mir-json' version/target combination"
-            echo "  mir-json-up run       Run a command within the active 'mir-json' version/target combination"
-            echo "  mir-json-up set       Set the active 'mir-json' version/target combination"
+            cat 1>&2 << EOM
+Usage: mir-json-up [--install-dir DIR] [--mir-json-version GIT-REF]
+         [--mir-json-rust-toolchain RUST-TOOLCHAIN] [--target-triplet TRIPLET] command
+Options:
+   --install-dir                 Directory holding the 'mir-json-up' installation
+                                    (default \$HOME/.mir-json-up)
+   --mir-json-version            Git reference for the version of 'mir-json' to use/install
+                                    (default 'master')
+   --mir-json-rust-toolchain     Rust toolchain to use (default is determined from the
+                                    'mir-json' version)
+   --target-triplet              Target triplet to use (default is derived from the Rust toolchain)
+Commands:"
+  mir-json-up check              Check if all requirements are in place for building 'mir-json'
+  mir-json-up help               Display this help (add a command name for command-specific help)
+  mir-json-up init               Install 'mir-json-up'
+  mir-json-up install            Download and build a specific version of 'mir-json' for a specific target
+  mir-json-up list               List all version/target 'mir-json' combinations installed
+  mir-json-up remove             Remove the given 'mir-json' version/target combination
+  mir-json-up run                Run a command within the active 'mir-json' version/target combination
+  mir-json-up set                Set the active 'mir-json' version/target combination
+EOM
             ;;
     esac
 }
 
-SCRIPT_FILE=$(realpath "$0")
+SCRIPT_FILE=$0
 
 while (( "$#" )); do
     case "$1" in
         "--install-dir")
+            if [[ $# < 2 ]]; then
+                echo "--install-dir requires an argument" 1>&2
+                exit 1
+            fi
             MIR_JSON_INSTALL_DIR="$2"
             shift 2
             ;;
         "--mir-json-version")
+            if [[ $# < 2 ]]; then
+                echo "--mir-json-version requires an argument" 1>&2
+                exit 1
+            fi
             MIR_JSON_VERSION="$2"
             shift 2
             ;;
         "--mir-json-rust-toolchain")
+            if [[ $# < 2 ]]; then
+                echo "--mir-json-rust-toolchain requires an argument" 1>&2
+                exit 1
+            fi
             MIR_JSON_RUST_TOOLCHAIN="$2"
             shift 2
             ;;
         "--target-triplet")
+            if [[ $# < 2 ]]; then
+                echo "--target-triplet requires an argument" 1>&2
+                exit 1
+            fi
             TARGET_TRIPLET="$2"
             shift 2
             ;;
         check|init|install|list|remove|run|set)
+            COMMAND="$1"
+            shift 1
+            if [[ "$1" != "" ]]; then
+                display_help "$COMMAND"
+                echo "Command '$COMMAND' does not accept positional arguments" 1>&2
+                exit 1
+            fi
+            break
+            ;;
+        run)
             COMMAND="$1"
             shift 1
             if [[ "$1" == "--" ]]; then
@@ -278,7 +344,8 @@ while (( "$#" )); do
             exit 0
             ;;
         *)
-            echo "Invalid command: $1"
+            display_help
+            echo "Invalid command: $1" 1>&2
             exit 1
             ;;
     esac
@@ -299,45 +366,62 @@ case "$COMMAND" in
     init)
         check_installation_dir 0
         build_env
-        echo "Successfully initialized mir-json-up"
-	    echo "To configure a shell, run or insert the following into your initialization script:"
-        echo "  . ${MIR_JSON_INSTALL_DIR}/env"
+        echo "Successfully initialized mir-json-up" 1>&2
+	    echo "To configure a shell, run or insert the following into your initialization script:" 1>&2
+        echo "  . ${MIR_JSON_INSTALL_DIR}/env" 1>&2
         ;;
     install)
         check_all_prerequisites 0
         if [[ ! -d "${MIR_JSON_INSTALL_DIR}" ]]; then
-            echo "${MIR_JSON_INSTALL_DIR} does not exist"
+            echo "${MIR_JSON_INSTALL_DIR} does not exist" 1>&2
             exit 1
         fi
         get_mir_json_src
         build_mir_json
+        cleanup_mir_json_src
         ;;
     list)
         check_general_prerequisites
         if [[ ! -e "${MIR_JSON_INSTALL_DIR}" ]]; then
-            echo "${MIR_JSON_INSTALL_DIR} does not exist"
+            echo "${MIR_JSON_INSTALL_DIR} does not exist" 1>&2
             exit 1
         fi
         cd "${MIR_JSON_INSTALL_DIR}/toolchains"
-        find */*/* -maxdepth 0 -type d
+        for toolchain in $(ls -1d */*/* | grep -v "[*]/[*]/[*]"); do
+            echo -n "$toolchain"
+            if [[ -f "${MIR_JSON_INSTALL_DIR}/default/id" ]]; then
+                ACTIVE_TOOLCHAIN=$(cat "${MIR_JSON_INSTALL_DIR}/default/id")
+                if [[ "${ACTIVE_TOOLCHAIN}" == "${toolchain}" ]]; then
+                    echo " (active)"
+                else
+                    echo ""
+                fi
+            else
+                echo ""
+            fi
+        done
         ;;
     remove)
         check_general_prerequisites
         if [[ ! -e "${MIR_JSON_INSTALL_DIR}" ]]; then
-            echo "${MIR_JSON_INSTALL_DIR} does not exist"
+            echo "${MIR_JSON_INSTALL_DIR} does not exist" 1>&2
             exit 1
         fi
         TOOLCHAIN_DIR="$(get_toolchain_dir)"
+        if [[ $(toolchain_is_default "$TOOLCHAIN_DIR") == 0 ]]; then
+            echo "Cannot remove the active version" 1>&2
+            exit 1
+        fi
         rm -rf "${TOOLCHAIN_DIR}"
         ;;
     run)
         check_all_prerequisites
         if [[ ! -e "${MIR_JSON_INSTALL_DIR}/env" ]]; then
-            echo "Cannot run before building: ${MIR_JSON_INSTALL_DIR}/env does not exist"
+            echo "Cannot run before building: ${MIR_JSON_INSTALL_DIR}/env does not exist" 1>&2
             exit 1
         fi
         . "${MIR_JSON_INSTALL_DIR}/env"
-        $@
+        "$@"
         ;;
     set)
         check_all_prerequisites
@@ -348,7 +432,8 @@ case "$COMMAND" in
         exit 1
         ;;
     *)
-        echo "Invalid command: ${COMMAND}"
+        display_help
+        echo "Invalid command: ${COMMAND}" 1>&2
         exit 1
         ;;
 esac

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -222,10 +222,15 @@ check_general_prerequisites() {
             echo "Checking out source repository for mir-json ${MIR_JSON_VERSION}" 1>&2
             get_mir_json_src "${MIR_JSON_VERSION}"
        fi
-    fi
-    if [[ ! -d "$(get_mir_json_src_dir ${MIR_JSON_VERSION})" ]]; then
-        echo "mir-json ${MIR_JSON_VERSION} not checked out" 1>&2
-        exit 1
+        if [[ ! -d "$(get_mir_json_src_dir ${MIR_JSON_VERSION})" ]]; then
+            echo "mir-json ${MIR_JSON_VERSION} failed to check out" 1>&2
+            exit 1
+        fi
+    else
+        if [[ ! -d "$(get_mir_json_src_dir ${MIR_JSON_VERSION})" ]]; then
+            echo "mir-json ${MIR_JSON_VERSION} not checked out" 1>&2
+            exit 1
+        fi
     fi
 }
 

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -7,11 +7,11 @@ require_tool() {
     local TOOL_NAME="$2"
     set +e
     TOOL_PATH=$(which "${TOOL_EXEC}")
-    set -e
     if [[ "$?" != 0 ]]; then
         echo "This script requires ${TOOL_NAME}"
         exit 1
     fi
+    set -e
 }
 
 require_rust_component() {
@@ -37,12 +37,18 @@ check_rust_toolchain() {
         echo "  rustup toolchain install ${MIR_JSON_RUST_TOOLCHAIN}"
         exit 1
     fi
+    if [[ $(rustup target list --installed | grep "${TARGET_TRIPLET}") == "" ]]; then
+        echo "Target ${TARGET_TRIPLET} not installed; install with"
+        echo "  rustup target add ${TARGET_TRIPLET}"
+        exit 1
+    fi
 }
 
 get_toolchain_dir() {
-    local TOOLCHAIN="${1:-${MIR_JSON_RUST_TOOLCHAIN}}"
-    local TARGET="${2:-${TARGET_TRIPLET}}"
-    echo "${MIR_JSON_INSTALL_DIR}/toolchains/${TOOLCHAIN}/${TARGET}"
+    local VERSION="${1:-${MIR_JSON_VERSION}}" 
+    local TOOLCHAIN="${2:-${MIR_JSON_RUST_TOOLCHAIN}}"
+    local TARGET="${3:-${TARGET_TRIPLET}}"
+    echo "${MIR_JSON_INSTALL_DIR}/toolchains/${VERSION}/${TOOLCHAIN}/${TARGET}"
 }
 
 get_mir_json_src() {
@@ -52,6 +58,44 @@ get_mir_json_src() {
     if ! [[ -d mir-json ]]; then
         git clone https://github.com/GaloisInc/mir-json.git
     fi
+    cd mir-json
+    set +e
+    if [[ $(git show-ref refs/tags/"${MIR_JSON_VERSION}") == "" ]]; then
+        git pull
+    fi
+    set -e
+    git checkout "${MIR_JSON_VERSION}"
+}
+
+create_installation_dir() {
+    if [[ -d "${MIR_JSON_INSTALL_DIR}/default/bin" ]]; then
+          rm -rf "${MIR_JSON_INSTALL_DIR}/default/bin"
+    fi
+    mkdir -p "${MIR_JSON_INSTALL_DIR}/default/bin"
+    cd "${MIR_JSON_INSTALL_DIR}/default/bin"
+    ln -s ../../mir-json-up
+    if [[ ! -e "${MIR_JSON_INSTALL_DIR}/mir-json-up" ]]; then
+         cp "${SCRIPT_FILE}" "${MIR_JSON_INSTALL_DIR}/mir-json-up"
+    fi
+}
+
+create_default_symlinks() {
+    local TOOLCHAIN_DIR="$1"
+    local MIR_JSON_SRC_DIR="${TOOLCHAIN_DIR}/src"
+    local MIR_JSON_BIN_DIR="${TOOLCHAIN_DIR}/bin/${TARGET_TRIPLET}/release"
+    local MIR_JSON_RLIBS_DIR="${TOOLCHAIN_DIR}/rlibs"
+
+    if [[ -d "${MIR_JSON_INSTALL_DIR}/default" ]]; then
+        rm -rf "${MIR_JSON_INSTALL_DIR}/default"
+    fi
+    create_installation_dir
+    for execFile in $(find "${MIR_JSON_BIN_DIR}" -maxdepth 1 -type f); do
+        if [[ -x "${execFile}" ]]; then
+            ln -s "${execFile}"
+        fi
+    done
+    cd ..
+    ln -s "${MIR_JSON_RLIBS_DIR}" rlibs
 }
 
 build_mir_json() {
@@ -60,8 +104,8 @@ build_mir_json() {
     local MIR_JSON_RLIBS_DIR="$(get_toolchain_dir)/rlibs"
     mkdir -p "${MIR_JSON_BIN_DIR}"
     cd "${MIR_JSON_SRC_DIR}/mir-json"
-    cargo +"${MIR_JSON_RUST_TOOLCHAIN}" build -r --target-dir "${MIR_JSON_BIN_DIR}" --locked
-    PATH="${MIR_JSON_BIN_DIR}/release:$PATH"
+    cargo +"${MIR_JSON_RUST_TOOLCHAIN}" build -r --target "${TARGET_TRIPLET}" --target-dir "${MIR_JSON_BIN_DIR}" --locked
+    PATH="${MIR_JSON_BIN_DIR}/${TARGET_TRIPLET}/release:$PATH"
     echo $PATH
     mir-json-translate-libs
     if [[ $? == 0 ]]; then
@@ -70,14 +114,42 @@ build_mir_json() {
         fi
         cp -RL rlibs "${MIR_JSON_RLIBS_DIR}"
     fi
+    if [[ ! -d "${MIR_JSON_INSTALL_DIR}/default/bin/mir-json" ]]; then
+        create_default_symlinks "$(get_toolchain_dir)"
+    fi
+}
+
+get_toolchain_from_version() {
+    local VERSION="${1:-${MIR_JSON_VERSION}}"
+    case "$VERSION" in
+       *)
+           echo "nightly-2025-09-14"
+           ;;
+    esac
+}
+
+target_triplet_from_cc() {
+    local TRIPLET=$(cc -dumpmachine)
+    case "$TRIPLET" in
+        x86_64-linux-gnu)
+           echo "x86_64-unknown-linux-gnu"
+           ;;
+        *)
+           echo "$TRIPLET"
+    esac    
+}
+
+check_general_prerequisites() {
+    check_tools
+
+    MIR_JSON_INSTALL_DIR="${MIR_JSON_INSTALL_DIR:-${HOME}/.mir-json-up}"
+    MIR_JSON_VERSION="${MIR_JSON_VERSION:-master}"
+    MIR_JSON_RUST_TOOLCHAIN="${MIR_JSON_RUST_TOOLCHAIN:-$(get_toolchain_from_version ${MIR_JSON_VERSION})}"
+    TARGET_TRIPLET="${TARGET_TRIPLET:-$(target_triplet_from_cc)}"
 }
 
 check_all_prerequisites() {
-    check_tools
-
-    MIR_JSON_INSTALL_DIR=${MIR_JSON_INSTALL_DIR:-~/.mir-json-up}
-    MIR_JSON_RUST_TOOLCHAIN=${MIR_JSON_RUST_TOOLCHAIN:-nightly-2025-09-14}
-    TARGET_TRIPLET=${TARGET_TRIPLET:-$(cc -dumpmachine)}
+    check_general_prerequisites
 
     check_rust_toolchain
 
@@ -90,19 +162,26 @@ build_env() {
     cat <<EOF >> "${MIR_JSON_INSTALL_DIR}/env"
 #!/bin/sh
 case ":\${PATH}:" in
-   *:"${TOOLCHAIN_DIR}/bin/release":*)
+   *:"${MIR_JSON_INSTALL_DIR}/default/bin":*)
        ;;
    *)
-       export PATH="${TOOLCHAIN_DIR}/bin/release:$PATH"
+       export PATH="${MIR_JSON_INSTALL_DIR}/default/bin:$PATH"
 esac
-export CRUX_RUST_LIBRARY_PATH="${TOOLCHAIN_DIR}/rlibs"
+export CRUX_RUST_LIBRARY_PATH="${MIR_JSON_INSTALL_DIR}/default/rlibs"
 EOF
 }
 
+SCRIPT_FILE=$(realpath "$0")
 COMMAND="$1"
 shift 1
 
 case "$COMMAND" in
+    build)
+        check_all_prerequisites
+        create_installation_dir
+        get_mir_json_src
+        build_mir_json
+        ;;
     check)
         check_all_prerequisites
         echo "All prerequisites in place"
@@ -110,13 +189,21 @@ case "$COMMAND" in
         echo "  Installing into: $MIR_JSON_INSTALL_DIR"
         echo "  Target: $TARGET_TRIPLET"
         ;;
-    build)
+    init)
         check_all_prerequisites
-        get_mir_json_src
-        build_mir_json
-        build_env
-        echo "Successfully built mir-json"
+        create_installation_dir
+        build_env        
+        echo "Successfully initialized mir-json-up"
         echo "To configure the current shell, run . ${MIR_JSON_INSTALL_DIR}/env"
+        ;;
+    list)
+        check_general_prerequisites
+        if [[ ! -e "${MIR_JSON_INSTALL_DIR}" ]]; then
+            echo "${MIR_JSON_INSTALL_DIR} does not exist"
+            exit 1
+        fi
+        cd "${MIR_JSON_INSTALL_DIR}/toolchains"
+        find */*/* -maxdepth 0 -type d
         ;;
     run)
         check_all_prerequisites
@@ -126,6 +213,19 @@ case "$COMMAND" in
         fi
         . "${MIR_JSON_INSTALL_DIR}/env"
         $@
+        ;;
+    set)
+        check_general_prerequisites
+        create_default_symlinks "$(get_toolchain_dir)"
+        ;;
+    help)
+        echo "Usage:"
+        echo "  mir-json-up build   Download and build a specific version of 'mir-json' for a specific target"
+        echo "  mir-json-up check   Check if all requirements are in place for building 'mir-json'"
+        echo "  mir-json-up init    Install 'mir-json-up'"
+        echo "  mir-json-up list    List all version/target 'mir-json' combinations installed"
+        echo "  mir-json-up run     Run a command within the active 'mir-json' version/target combination"
+        echo "  mir-json-up set     Set the active 'mir-json' version/target combination"
         ;;
     *)
         echo "Invalid command: ${COMMAND}"

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -134,6 +134,8 @@ target_triplet_from_cc() {
         x86_64-linux-gnu)
            echo "x86_64-unknown-linux-gnu"
            ;;
+        arm64-apple-darwin*)
+           echo "aarch64-apple-darwin"
         *)
            echo "$TRIPLET"
     esac    

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -14,8 +14,20 @@ require_tool() {
     set -e
 }
 
+require_rust_toolchain() {
+    local RUST_TOOLCHAIN="${1:-${MIR_JSON_RUST_TOOLCHAIN}}"
+    pushd "${MIR_JSON_INSTALL_DIR}" > /dev/null
+    if [[ $(rustup toolchain list | grep "${RUST_TOOLCHAIN}") == "" ]]; then
+        echo "Building mir-json requires the Rust toolchain ${RUST_TOOLCHAIN}; install it with"
+        echo "  rustup toolchain install ${RUST_TOOLCHAIN}"
+        exit 1
+    fi
+    popd > /dev/null
+}
+
 require_rust_component() {
     local COMPONENT_NAME="$1"
+    require_rust_toolchain "${MIR_JSON_RUST_TOOLCHAIN}"
     if [[ $(rustup component list --toolchain "${MIR_JSON_RUST_TOOLCHAIN}" --installed | grep -c "^${COMPONENT_NAME}") == 0 ]]; then
         echo "Building mir-json requires the Rust component ${COMPONENT_NAME}; install it with"
         echo "  rustup component add --toolchain \"${MIR_JSON_RUST_TOOLCHAIN}\" ${COMPONENT_NAME}"
@@ -32,11 +44,7 @@ check_tools() {
 }
 
 check_rust_toolchain() {
-    if [[ $(rustup toolchain list | grep "${MIR_JSON_RUST_TOOLCHAIN}") == "" ]]; then
-        echo "Building mir-json requires the Rust toolchain ${MIR_JSON_RUST_TOOLCHAIN}; install it with"
-        echo "  rustup toolchain install ${MIR_JSON_RUST_TOOLCHAIN}"
-        exit 1
-    fi
+    require_rust_toolchain "${MIR_JSON_RUST_TOOLCHAIN}"
     if [[ $(rustup target list --installed | grep "${TARGET_TRIPLET}") == "" ]]; then
         echo "Target ${TARGET_TRIPLET} not installed; install with"
         echo "  rustup target add ${TARGET_TRIPLET}"
@@ -45,16 +53,22 @@ check_rust_toolchain() {
 }
 
 get_toolchain_dir() {
-    local VERSION="${1:-${MIR_JSON_VERSION}}" 
+    local VERSION="${1:-${MIR_JSON_VERSION}}"
     local TOOLCHAIN="${2:-${MIR_JSON_RUST_TOOLCHAIN}}"
     local TARGET="${3:-${TARGET_TRIPLET}}"
     echo "${MIR_JSON_INSTALL_DIR}/toolchains/${VERSION}/${TOOLCHAIN}/${TARGET}"
 }
 
+get_mir_json_src_dir() {
+    local VERSION="${1:-${MIR_JSON_VERSION}}"
+    echo "${MIR_JSON_INSTALL_DIR}/src/${VERSION}"
+}
+
 get_mir_json_src() {
-    local MIR_JSON_SRC_DIR="$(get_toolchain_dir)/src"
+    local VERSION="${1:-${MIR_JSON_VERSION}}"
+    local MIR_JSON_SRC_DIR=$(get_mir_json_src_dir "$VERSION")
     mkdir -p "${MIR_JSON_SRC_DIR}"
-    cd "${MIR_JSON_SRC_DIR}"
+    pushd "${MIR_JSON_SRC_DIR}" > /dev/null
     if ! [[ -d mir-json ]]; then
         git clone https://github.com/GaloisInc/mir-json.git
     fi
@@ -65,6 +79,7 @@ get_mir_json_src() {
     fi
     set -e
     git checkout "${MIR_JSON_VERSION}"
+    popd > /dev/null
 }
 
 create_installation_dir() {
@@ -72,16 +87,16 @@ create_installation_dir() {
           rm -rf "${MIR_JSON_INSTALL_DIR}/default/bin"
     fi
     mkdir -p "${MIR_JSON_INSTALL_DIR}/default/bin"
-    cd "${MIR_JSON_INSTALL_DIR}/default/bin"
+    pushd "${MIR_JSON_INSTALL_DIR}/default/bin" > /dev/null
     ln -s ../../mir-json-up
     if [[ ! -e "${MIR_JSON_INSTALL_DIR}/mir-json-up" ]]; then
          cp "${SCRIPT_FILE}" "${MIR_JSON_INSTALL_DIR}/mir-json-up"
     fi
+    popd > /dev/null
 }
 
 create_default_symlinks() {
     local TOOLCHAIN_DIR="$1"
-    local MIR_JSON_SRC_DIR="${TOOLCHAIN_DIR}/src"
     local MIR_JSON_BIN_DIR="${TOOLCHAIN_DIR}/bin/${TARGET_TRIPLET}/release"
     local MIR_JSON_RLIBS_DIR="${TOOLCHAIN_DIR}/rlibs"
 
@@ -89,24 +104,26 @@ create_default_symlinks() {
         rm -rf "${MIR_JSON_INSTALL_DIR}/default"
     fi
     create_installation_dir
+    echo "${TOOLCHAIN_DIR}" > "${MIR_JSON_INSTALL_DIR}/default/id"
+    pushd "${MIR_JSON_INSTALL_DIR}/default/bin" > /dev/null
     for execFile in $(find "${MIR_JSON_BIN_DIR}" -maxdepth 1 -type f); do
         if [[ -x "${execFile}" ]]; then
             ln -s "${execFile}"
         fi
     done
-    cd ..
+    cd "${MIR_JSON_INSTALL_DIR}/default"
     ln -s "${MIR_JSON_RLIBS_DIR}" rlibs
+    popd > /dev/null
 }
 
 build_mir_json() {
-    local MIR_JSON_SRC_DIR="$(get_toolchain_dir)/src"
+    local MIR_JSON_SRC_DIR="$(get_mir_json_src_dir)"
     local MIR_JSON_BIN_DIR="$(get_toolchain_dir)/bin"
     local MIR_JSON_RLIBS_DIR="$(get_toolchain_dir)/rlibs"
     mkdir -p "${MIR_JSON_BIN_DIR}"
-    cd "${MIR_JSON_SRC_DIR}/mir-json"
+    pushd "${MIR_JSON_SRC_DIR}/mir-json" > /dev/null
     cargo +"${MIR_JSON_RUST_TOOLCHAIN}" build -r --target "${TARGET_TRIPLET}" --target-dir "${MIR_JSON_BIN_DIR}" --locked
     PATH="${MIR_JSON_BIN_DIR}/${TARGET_TRIPLET}/release:$PATH"
-    echo $PATH
     mir-json-translate-libs --target "${TARGET_TRIPLET}"
     if [[ $? == 0 ]]; then
         if [[ -e "${MIR_JSON_RLIBS_DIR}" ]]; then
@@ -117,47 +134,72 @@ build_mir_json() {
     if [[ ! -d "${MIR_JSON_INSTALL_DIR}/default/bin/mir-json" ]]; then
         create_default_symlinks "$(get_toolchain_dir)"
     fi
+    popd > /dev/null
 }
 
-get_toolchain_from_version() {
+get_toolchain_from_mir_json_version() {
     local VERSION="${1:-${MIR_JSON_VERSION}}"
-    case "$VERSION" in
-       *)
-           echo "nightly-2025-09-14"
-           ;;
-    esac
+    local MIR_JSON_SRC_DIR=$(get_mir_json_src_dir "${VERSION}")
+    echo $(cat "${MIR_JSON_SRC_DIR}/mir-json/rust-toolchain.toml" | grep "^channel = " | cut -f 2 -d '"')
 }
 
-target_triplet_from_cc() {
-    local TRIPLET=$(cc -dumpmachine)
-    case "$TRIPLET" in
-        x86_64-linux-gnu)
-           echo "x86_64-unknown-linux-gnu"
-           ;;
-        arm64-apple-darwin*)
-           echo "aarch64-apple-darwin"
-           ;;
-        *)
-           echo "$TRIPLET"
-    esac    
+get_target_triplet_from_toolchain() {
+    local RUST_TOOLCHAIN="${1:-${MIR_JSON_RUST_TOOLCHAIN}}"
+    pushd "${MIR_JSON_INSTALL_DIR}" > /dev/null
+    if [[ $(rustup toolchain list | grep "${RUST_TOOLCHAIN}") != "" ]]; then
+        echo $(rustc +"${RUST_TOOLCHAIN}" --print host-tuple)
+    fi
+    popd > /dev/null
+}
+
+check_installation_dir() {
+    local INITIALIZE_IF_MISSING=${1:-1}
+
+    MIR_JSON_INSTALL_DIR="${MIR_JSON_INSTALL_DIR:-${HOME}/.mir-json-up}"
+    if [[ ! -d "${MIR_JSON_INSTALL_DIR}" ]]; then
+       if [[ $INITIALIZE_IF_MISSING == 0 ]]; then
+            create_installation_dir
+       fi
+    fi
+    if [[ ! -d "${MIR_JSON_INSTALL_DIR}" ]]; then
+       echo "Install directory ${MIR_JSON_INSTALL_DIR} does not exist"
+       exit 1
+    fi
 }
 
 check_general_prerequisites() {
+    local INITIALIZE_IF_MISSING=${1:-1}
+
+    check_installation_dir "${INITIALIZE_IF_MISSING}"
+
     check_tools
 
-    MIR_JSON_INSTALL_DIR="${MIR_JSON_INSTALL_DIR:-${HOME}/.mir-json-up}"
     MIR_JSON_VERSION="${MIR_JSON_VERSION:-master}"
-    MIR_JSON_RUST_TOOLCHAIN="${MIR_JSON_RUST_TOOLCHAIN:-$(get_toolchain_from_version ${MIR_JSON_VERSION})}"
-    TARGET_TRIPLET="${TARGET_TRIPLET:-$(target_triplet_from_cc)}"
+    if [[ ! -d "$(get_mir_json_src_dir ${MIR_JSON_VERSION})" ]]; then
+       if [[ $INITIALIZE_IF_MISSING == 0 ]]; then
+            echo "Checking out source repository for mir-json ${MIR_JSON_VERSION}"
+            get_mir_json_src "${MIR_JSON_VERSION}"
+       fi
+    fi
+    if [[ ! -d "$(get_mir_json_src_dir ${MIR_JSON_VERSION})" ]]; then
+        echo "mir-json ${MIR_JSON_VERSION} not checked out"
+        exit 1
+    fi
 }
 
 check_all_prerequisites() {
-    check_general_prerequisites
+    local INITIALIZE_IF_MISSING=${1:-1}
+
+    check_general_prerequisites "${INITIALIZE_IF_MISSING}"
+
+    MIR_JSON_RUST_TOOLCHAIN="${MIR_JSON_RUST_TOOLCHAIN:-$(get_toolchain_from_mir_json_version ${MIR_JSON_VERSION})}"
 
     check_rust_toolchain
 
     require_rust_component rust-src
     require_rust_component rustc-dev
+
+    TARGET_TRIPLET="${TARGET_TRIPLET:-$(get_target_triplet_from_toolchain)}"
 }
 
 build_env() {
@@ -174,24 +216,32 @@ EOF
 }
 
 display_help() {
-    echo "Usage: mir-json-up [--install-dir DIR] [--mir-json-version GIT-REF]"
-    echo "         [--mir-json-rust-toolchain RUST-TOOLCHAIN] [--target-triplet TRIPLET] command"
-    echo "Options:"
-    echo "   --install-dir        Directory holding the 'mir-json-up' installation"
-    echo "                            (default \$HOME/.mir-json-up)"
-    echo "   --mir-json-version   Git reference for the version of 'mir-json' to use/install"
-    echo "                            (default 'master')"
-    echo "   --mir-json-rust-toolchain     Rust toolchain to use (default 'nightly-2025-09-14')"
-    echo "   --target-triplet     Target triplet to use (default is the output of cc -dumpmachine)"
-    echo "Commands:"
-    echo "  mir-json-up check     Check if all requirements are in place for building 'mir-json'"
-    echo "  mir-json-up help      Display this help"
-    echo "  mir-json-up init      Install 'mir-json-up'"
-    echo "  mir-json-up install   Download and build a specific version of 'mir-json' for a specific target"
-    echo "  mir-json-up list      List all version/target 'mir-json' combinations installed"
-    echo "  mir-json-up remove    Remove the given 'mir-json' version/target combination"
-    echo "  mir-json-up run       Run a command within the active 'mir-json' version/target combination"
-    echo "  mir-json-up set       Set the active 'mir-json' version/target combination"
+    case "$1" in
+        run)
+            echo "Usage: mir-json-up run [--] command-line"
+            echo "   Run the given command line within the active 'mir-json' version/target combination"
+            ;;
+        *)
+            echo "Usage: mir-json-up [--install-dir DIR] [--mir-json-version GIT-REF]"
+            echo "         [--mir-json-rust-toolchain RUST-TOOLCHAIN] [--target-triplet TRIPLET] command"
+            echo "Options:"
+            echo "   --install-dir        Directory holding the 'mir-json-up' installation"
+            echo "                            (default \$HOME/.mir-json-up)"
+            echo "   --mir-json-version   Git reference for the version of 'mir-json' to use/install"
+            echo "                            (default 'master')"
+            echo "   --mir-json-rust-toolchain     Rust toolchain to use (default 'nightly-2025-09-14')"
+            echo "   --target-triplet     Target triplet to use (default is the output of cc -dumpmachine)"
+            echo "Commands:"
+            echo "  mir-json-up check     Check if all requirements are in place for building 'mir-json'"
+            echo "  mir-json-up help      Display this help (add a command name for command-specific help)"
+            echo "  mir-json-up init      Install 'mir-json-up'"
+            echo "  mir-json-up install   Download and build a specific version of 'mir-json' for a specific target"
+            echo "  mir-json-up list      List all version/target 'mir-json' combinations installed"
+            echo "  mir-json-up remove    Remove the given 'mir-json' version/target combination"
+            echo "  mir-json-up run       Run a command within the active 'mir-json' version/target combination"
+            echo "  mir-json-up set       Set the active 'mir-json' version/target combination"
+            ;;
+    esac
 }
 
 SCRIPT_FILE=$(realpath "$0")
@@ -223,7 +273,8 @@ while (( "$#" )); do
             break
             ;;
         help)
-            display_help
+            shift 1
+            display_help $@
             exit 0
             ;;
         *)
@@ -239,20 +290,21 @@ case "$COMMAND" in
     check)
         check_all_prerequisites
         echo "All prerequisites in place"
-        echo "  Rust toolchain: $MIR_JSON_RUST_TOOLCHAIN"
-        echo "  Installing into: $MIR_JSON_INSTALL_DIR"
-        echo "  Target: $TARGET_TRIPLET"
+        echo "  Install directory: $MIR_JSON_INSTALL_DIR"
+        if [[ -f "${MIR_JSON_INSTALL_DIR}/default/id" ]]; then
+            echo "  Active mir-json installation:"
+            mir-json --version | sed 's/^/    /g'
+        fi
         ;;
     init)
-        check_all_prerequisites
-        create_installation_dir
-        build_env        
+        check_installation_dir 0
+        build_env
         echo "Successfully initialized mir-json-up"
 	    echo "To configure a shell, run or insert the following into your initialization script:"
         echo "  . ${MIR_JSON_INSTALL_DIR}/env"
         ;;
     install)
-        check_all_prerequisites
+        check_all_prerequisites 0
         if [[ ! -d "${MIR_JSON_INSTALL_DIR}" ]]; then
             echo "${MIR_JSON_INSTALL_DIR} does not exist"
             exit 1
@@ -275,7 +327,7 @@ case "$COMMAND" in
             echo "${MIR_JSON_INSTALL_DIR} does not exist"
             exit 1
         fi
-        local TOOLCHAIN_DIR="$(get_toolchain_dir)"
+        TOOLCHAIN_DIR="$(get_toolchain_dir)"
         rm -rf "${TOOLCHAIN_DIR}"
         ;;
     run)
@@ -288,11 +340,11 @@ case "$COMMAND" in
         $@
         ;;
     set)
-        check_general_prerequisites
+        check_all_prerequisites
         create_default_symlinks "$(get_toolchain_dir)"
         ;;
     help)
-        display_help
+        display_help "$1"
         exit 1
         ;;
     *)

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -128,6 +128,11 @@ create_default_symlinks() {
     local MIR_JSON_BIN_DIR="${TOOLCHAIN_DIR}/bin/${TARGET_TRIPLET}/release"
     local MIR_JSON_RLIBS_DIR="${TOOLCHAIN_DIR}/rlibs"
 
+    if [[ ! -d "${TOOLCHAIN_DIR}" ]]; then
+        echo "Cannot set active toolchain: ${TOOLCHAIN_DIR} does not exist"
+        exit 1
+    fi
+
     if [[ -d "${MIR_JSON_INSTALL_DIR}/default" ]]; then
         rm -rf "${MIR_JSON_INSTALL_DIR}/default"
     fi

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -158,7 +158,6 @@ check_all_prerequisites() {
 }
 
 build_env() {
-    local TOOLCHAIN_DIR=$(get_toolchain_dir)
     cat <<EOF >> "${MIR_JSON_INSTALL_DIR}/env"
 #!/bin/sh
 case ":\${PATH}:" in
@@ -171,17 +170,68 @@ export CRUX_RUST_LIBRARY_PATH="${MIR_JSON_INSTALL_DIR}/default/rlibs"
 EOF
 }
 
+display_help() {
+    echo "Usage: mir-json-up [--install-dir DIR] [--mir-json-version GIT-REF]"
+    echo "         [--mir-json-rust-toolchain RUST-TOOLCHAIN] [--target-triplet TRIPLET] command"
+    echo "Options:"
+    echo "   --install-dir        Directory holding the 'mir-json-up' installation"
+    echo "                            (default \$HOME/.mir-json-up)"
+    echo "   --mir-json-version   Git reference for the version of 'mir-json' to use/install"
+    echo "                            (default 'master')"
+    echo "   --mir-json-rust-toolchain     Rust toolchain to use (default 'nightly-2025-09-14')"
+    echo "   --target-triplet     Target triplet to use (default is the output of cc -dumpmachine)"
+    echo "Commands:"
+    echo "  mir-json-up check     Check if all requirements are in place for building 'mir-json'"
+    echo "  mir-json-up init      Install 'mir-json-up'"
+    echo "  mir-json-up install   Download and build a specific version of 'mir-json' for a specific target"
+    echo "  mir-json-up list      List all version/target 'mir-json' combinations installed"
+    echo "  mir-json-up remove    Remove the given 'mir-json' version/target combination"
+    echo "  mir-json-up run       Run a command within the active 'mir-json' version/target combination"
+    echo "  mir-json-up set       Set the active 'mir-json' version/target combination"
+}
+
 SCRIPT_FILE=$(realpath "$0")
-COMMAND="$1"
-shift 1
+
+while (( "$#" )); do
+    case "$1" in
+        "--install-dir")
+            MIR_JSON_INSTALL_DIR="$2"
+            shift 2
+            ;;
+        "--mir-json-version")
+            MIR_JSON_VERSION="$2"
+            shift 2
+            ;;
+        "--mir-json-rust-toolchain")
+            MIR_JSON_RUST_TOOLCHAIN="$2"
+            shift 2
+            ;;
+        "--target-triplet")
+            TARGET_TRIPLET="$2"
+            shift 2
+            ;;
+        check|init|install|list|remove|run|set)
+            COMMAND="$1"
+            shift 1
+            if [[ "$1" == "--" ]]; then
+                shift 1
+            fi
+            break
+            ;;
+        help)
+            display_help
+            exit 0
+            ;;
+        *)
+            echo "Invalid command: $1"
+            exit 1
+            ;;
+    esac
+done
+
+COMMAND="${COMMAND:-help}"
 
 case "$COMMAND" in
-    build)
-        check_all_prerequisites
-        create_installation_dir
-        get_mir_json_src
-        build_mir_json
-        ;;
     check)
         check_all_prerequisites
         echo "All prerequisites in place"
@@ -196,6 +246,15 @@ case "$COMMAND" in
         echo "Successfully initialized mir-json-up"
         echo "To configure the current shell, run . ${MIR_JSON_INSTALL_DIR}/env"
         ;;
+    install)
+        check_all_prerequisites
+        if [[ ! -d "${MIR_JSON_INSTALL_DIR}" ]]; then
+            echo "${MIR_JSON_INSTALL_DIR} does not exist"
+            exit 1
+        fi
+        get_mir_json_src
+        build_mir_json
+        ;;
     list)
         check_general_prerequisites
         if [[ ! -e "${MIR_JSON_INSTALL_DIR}" ]]; then
@@ -204,6 +263,14 @@ case "$COMMAND" in
         fi
         cd "${MIR_JSON_INSTALL_DIR}/toolchains"
         find */*/* -maxdepth 0 -type d
+        ;;
+    remove)
+        if [[ ! -e "${MIR_JSON_INSTALL_DIR}" ]]; then
+            echo "${MIR_JSON_INSTALL_DIR} does not exist"
+            exit 1
+        fi
+        local TOOLCHAIN_DIR="$(get_toolchain_dir)"
+        rm -rf "${TOOLCHAIN_DIR}"
         ;;
     run)
         check_all_prerequisites
@@ -219,17 +286,11 @@ case "$COMMAND" in
         create_default_symlinks "$(get_toolchain_dir)"
         ;;
     help)
-        echo "Usage:"
-        echo "  mir-json-up build   Download and build a specific version of 'mir-json' for a specific target"
-        echo "  mir-json-up check   Check if all requirements are in place for building 'mir-json'"
-        echo "  mir-json-up init    Install 'mir-json-up'"
-        echo "  mir-json-up list    List all version/target 'mir-json' combinations installed"
-        echo "  mir-json-up run     Run a command within the active 'mir-json' version/target combination"
-        echo "  mir-json-up set     Set the active 'mir-json' version/target combination"
+        display_help
+        exit 1
         ;;
     *)
         echo "Invalid command: ${COMMAND}"
         exit 1
         ;;
 esac
-

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -95,7 +95,6 @@ get_mir_json_src() {
     if ! [[ -d mir-json ]]; then
         git clone https://github.com/GaloisInc/mir-json.git
     fi
-    cp mir-json/rust-toolchain.toml .
     cd mir-json
     set +e
     if [[ $(git show-ref refs/tags/"${MIR_JSON_VERSION}") == "" ]]; then
@@ -103,6 +102,7 @@ get_mir_json_src() {
     fi
     set -e
     git checkout "${MIR_JSON_VERSION}"
+    cp rust-toolchain.toml ..
     popd > /dev/null
 }
 
@@ -161,13 +161,17 @@ build_mir_json() {
     cargo +"${MIR_JSON_RUST_TOOLCHAIN}" build -r --target "${TARGET_TRIPLET}" --target-dir "${MIR_JSON_BIN_DIR}" --locked
     PATH="${MIR_JSON_BIN_DIR}/${TARGET_TRIPLET}/release:$PATH"
     mir-json-translate-libs --target "${TARGET_TRIPLET}"
-    if [[ $? ]]; then
+    if [ $? = 0 ]; then
         if [[ -e "${MIR_JSON_RLIBS_DIR}" ]]; then
-            rm -rfv "${MIR_JSON_RLIBS_DIR}"
+            rm -rf "${MIR_JSON_RLIBS_DIR}"
         fi
-        tar cf rlibs.tar rlibs
+        cd rlibs
+        tar cf "${MIR_JSON_SRC_DIR}/mir-json/rlibs.tar" .
         pushd "$(get_toolchain_dir)" > /dev/null
+        mkdir rlibs
+        cd rlibs
         tar xf "${MIR_JSON_SRC_DIR}/mir-json/rlibs.tar"
+        popd
     fi
     if [[ ! -f "${MIR_JSON_INSTALL_DIR}/default/bin/mir-json" ]]; then
         create_default_symlinks "$(get_toolchain_dir)"
@@ -385,7 +389,7 @@ case "$COMMAND" in
     install)
         check_all_prerequisites 0
         if [[ ! -d "${MIR_JSON_INSTALL_DIR}" ]]; then
-            echo "${MIR_JSON_INSTALL_DIR} does not exist" 1>&2
+            echo "${MIR_JSON_INSTALL_DIR} does not exist; run 'mir-json-up init' to initialize" 1>&2
             exit 1
         fi
         get_mir_json_src
@@ -395,7 +399,7 @@ case "$COMMAND" in
     list)
         check_general_prerequisites
         if [[ ! -e "${MIR_JSON_INSTALL_DIR}" ]]; then
-            echo "${MIR_JSON_INSTALL_DIR} does not exist" 1>&2
+            echo "${MIR_JSON_INSTALL_DIR} does not exist; run 'mir-json-up init' to initialize" 1>&2
             exit 1
         fi
         if [[ ! -d "${MIR_JSON_INSTALL_DIR}/toolchains" || -z $(ls -A "${MIR_JSON_INSTALL_DIR}/toolchains") ]]; then
@@ -419,7 +423,7 @@ case "$COMMAND" in
     remove)
         check_general_prerequisites
         if [[ ! -e "${MIR_JSON_INSTALL_DIR}" ]]; then
-            echo "${MIR_JSON_INSTALL_DIR} does not exist" 1>&2
+            echo "${MIR_JSON_INSTALL_DIR} does not exist; run 'mir-json-up init' to initialize" 1>&2
             exit 1
         fi
         TOOLCHAIN_DIR="$(get_toolchain_dir)"

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+# Remove space from IFS to avoid splitting filenames that contain spaces.
 IFS='
 '
 
@@ -131,7 +132,7 @@ create_default_symlinks() {
     local MIR_JSON_RLIBS_DIR="${TOOLCHAIN_DIR}/rlibs"
 
     if [[ ! -d "${TOOLCHAIN_DIR}" ]]; then
-        echo "Cannot set active toolchain: ${TOOLCHAIN_DIR} does not exist"
+        echo "Cannot set active toolchain: ${TOOLCHAIN_DIR} does not exist" 1>&2
         exit 1
     fi
 

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -171,7 +171,7 @@ build_mir_json() {
         mkdir rlibs
         cd rlibs
         tar xf "${MIR_JSON_SRC_DIR}/mir-json/rlibs.tar"
-        popd
+        popd > /dev/null
     fi
     if [[ ! -f "${MIR_JSON_INSTALL_DIR}/default/bin/mir-json" ]]; then
         create_default_symlinks "$(get_toolchain_dir)"

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -244,7 +244,8 @@ case "$COMMAND" in
         create_installation_dir
         build_env        
         echo "Successfully initialized mir-json-up"
-        echo "To configure the current shell, run . ${MIR_JSON_INSTALL_DIR}/env"
+	    echo "To configure a shell, run or insert the following into your initialization script:"
+        echo "  . ${MIR_JSON_INSTALL_DIR}/env"
         ;;
     install)
         check_all_prerequisites
@@ -265,6 +266,7 @@ case "$COMMAND" in
         find */*/* -maxdepth 0 -type d
         ;;
     remove)
+        check_general_prerequisites
         if [[ ! -e "${MIR_JSON_INSTALL_DIR}" ]]; then
             echo "${MIR_JSON_INSTALL_DIR} does not exist"
             exit 1

--- a/mir-json-up/mir-json-up
+++ b/mir-json-up/mir-json-up
@@ -107,7 +107,7 @@ build_mir_json() {
     cargo +"${MIR_JSON_RUST_TOOLCHAIN}" build -r --target "${TARGET_TRIPLET}" --target-dir "${MIR_JSON_BIN_DIR}" --locked
     PATH="${MIR_JSON_BIN_DIR}/${TARGET_TRIPLET}/release:$PATH"
     echo $PATH
-    mir-json-translate-libs
+    mir-json-translate-libs --target "${TARGET_TRIPLET}"
     if [[ $? == 0 ]]; then
         if [[ -e "${MIR_JSON_RLIBS_DIR}" ]]; then
             rm -rfv "${MIR_JSON_RLIBS_DIR}"
@@ -184,6 +184,7 @@ display_help() {
     echo "   --target-triplet     Target triplet to use (default is the output of cc -dumpmachine)"
     echo "Commands:"
     echo "  mir-json-up check     Check if all requirements are in place for building 'mir-json'"
+    echo "  mir-json-up help      Display this help"
     echo "  mir-json-up init      Install 'mir-json-up'"
     echo "  mir-json-up install   Download and build a specific version of 'mir-json' for a specific target"
     echo "  mir-json-up list      List all version/target 'mir-json' combinations installed"


### PR DESCRIPTION
This pull request introduces a command-line tool, `mir-json-up`, for managing `mir-json` installations roughly along the lines of `rustup`, individual installations being identified by a triple of (1) the `mir-json` commit ref, (2) the Rust toolchain version, and (3) the target triplet.

It has been tested to the level of installing a single version of `mir-json` and successfully running the tests via `run-all.sh` on a couple of Linux distributions and macOS.

Known caveats:

* The script's method of calculating the target triplet could be improved upon.
* There is no proper mapping between `mir-json` versions and Rust toolchains, or anything preventing the user from trying to build `mir-json` on the wrong toolchain.

Fixes https://github.com/GaloisInc/mir-json/issues/252.