### PR TITLE
link: read all inputs into memory up front

### DIFF
--- a/src/bin/mir-json-callgraph.rs
+++ b/src/bin/mir-json-callgraph.rs
@@ -12,7 +12,7 @@ extern crate mir_json;
 
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::fs::File;
+use std::fs;
 use std::io;
 use serde_json::Value as JsonValue;
 use mir_json::lib_util::{StringId, InternTable};
@@ -27,9 +27,10 @@ fn main() {
     }
 
     let root_name = env::args().nth(1).unwrap();
-    let mut inputs = env::args().skip(2).map(|arg| File::open(&arg))
-        .collect::<io::Result<Vec<_>>>().unwrap();
-    let (mut it, calls) = link::gather_calls(&mut inputs).unwrap();
+    let inputs = env::args().skip(2).map(|arg| {
+        fs::read(&arg)
+    }).collect::<Result<Vec<Vec<u8>>, _>>().unwrap();
+    let (mut it, calls) = link::gather_calls(&inputs).unwrap();
 
     let mut map = HashMap::new();
     for (a, b) in calls {

--- a/src/bin/mir-json-dce.rs
+++ b/src/bin/mir-json-dce.rs
@@ -14,7 +14,7 @@ extern crate mir_json;
 extern crate rustc_log;
 
 use std::env;
-use std::fs::File;
+use std::fs;
 use std::io;
 use std::time::Instant;
 use mir_json::link;
@@ -38,9 +38,10 @@ fn main() {
         dur
     };
 
-    let mut inputs = env::args().skip(1).map(|arg| File::open(&arg))
-        .collect::<io::Result<Vec<_>>>().unwrap();
+    let inputs = env::args().skip(1).map(|arg| {
+        fs::read(&arg)
+    }).collect::<Result<Vec<Vec<u8>>, _>>().unwrap();
     let output = io::BufWriter::new(io::stdout());
-    link::link_crates(&mut inputs, output).unwrap();
+    link::link_crates(&inputs, output).unwrap();
     debug!("{:?}: link crates", measure());
 }

--- a/src/bin/mir-json-rustc-wrapper.rs
+++ b/src/bin/mir-json-rustc-wrapper.rs
@@ -29,7 +29,7 @@ use rustc_session::config::{Externs, ExternLocation, OutFileName, OutputFilename
 use rustc_span::Symbol;
 use std::collections::HashSet;
 use std::env;
-use std::fs::{File, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
 use std::iter;
 use std::os::unix::fs::OpenOptionsExt;
@@ -161,11 +161,11 @@ impl rustc_driver::Callbacks for MirJsonCallbacks {
 }
 
 fn link_mirs(main_path: PathBuf, extern_paths: &[PathBuf], out_path: &Path) {
-    let mut inputs = iter::once(&main_path).chain(extern_paths.iter())
-        .map(File::open)
-        .collect::<io::Result<Vec<_>>>().unwrap();
+    let inputs = iter::once(&main_path).chain(extern_paths.iter()).map(|arg| {
+        fs::read(&arg)
+    }).collect::<Result<Vec<Vec<u8>>, _>>().unwrap();
     let output = io::BufWriter::new(File::create(out_path).unwrap());
-    link::link_crates(&mut inputs, output).unwrap();
+    link::link_crates(&inputs, output).unwrap();
 }
 
 fn write_test_script(script_path: &Path, json_path: &Path) -> io::Result<()> {

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -18,9 +18,10 @@
 //! live items is known, those items can be copied directly into the output JSON without parsing.
 
 use std::borrow::Cow;
+use std::convert::TryFrom;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{self, Read, Write, Seek, SeekFrom, Cursor, BufWriter};
+use std::io::{self, Write, Cursor, BufWriter};
 use std::path::Path;
 
 use serde_json::Value as JsonValue;
@@ -61,7 +62,7 @@ pub struct ItemData {
 
     /// The location of each entry for this item.  The first `u64` is the offset of the entry's
     /// JSON representation within `crates.json`, and the second `u64` is the length.
-    pub locations: HashMap<EntryKind, (u64, u64)>,
+    pub locations: HashMap<EntryKind, (usize, usize)>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize)]
@@ -178,7 +179,7 @@ impl<W: Write> Write for CountWrite<W> {
 #[derive(Default)]
 struct EmitterState {
     dep_map: HashMap<StringId, HashSet<StringId>>,
-    entry_loc: HashMap<(StringId, EntryKind), (u64, u64)>,
+    entry_loc: HashMap<(StringId, EntryKind), (usize, usize)>,
     roots: HashSet<StringId>,
     tests: HashSet<StringId>,
     intern: InternTable,
@@ -210,7 +211,7 @@ impl EmitterState {
         }
     }
 
-    fn emit_entry<E, F: FnOnce(EntryKind, &JsonValue) -> Result<(u64, u64), E>>(
+    fn emit_entry<E, F: FnOnce(EntryKind, &JsonValue) -> Result<(usize, usize), E>>(
         &mut self,
         kind: EntryKind,
         j: &JsonValue,
@@ -283,9 +284,9 @@ impl<W: Write> Emitter<W> {
     fn emit_entry(&mut self, kind: EntryKind, j: &JsonValue) -> io::Result<()> {
         let writer = &mut self.writer;
         self.state.emit_entry(kind, j, |_, j| {
-            let start = writer.count as u64;
+            let start = writer.count;
             serde_json::to_writer(&mut *writer, j)?;
-            let end = writer.count as u64;
+            let end = writer.count;
             Ok((start, end))
         })
     }
@@ -389,29 +390,69 @@ where W: Write + Send + 'static {
 
 /// Read the crate index.  Also returns the byte offset of the start of `crate.json`, to avoid a
 /// second scan over the archive.
-pub fn read_crate_index<R: Read + Seek>(mut input: R) -> serde_cbor::Result<(CrateIndex, u64)> {
-    input.seek(SeekFrom::Start(0))?;
-    let mut tar = tar::Archive::new(input);
+pub fn read_crate_index(input: impl AsRef<[u8]>) -> serde_cbor::Result<(CrateIndex, usize)> {
+    let input = input.as_ref();
 
     let mut index = None;
     let mut json_offset = None;
 
-    for entry in tar.entries()? {
-        let entry = entry?;
-        let path = entry.path()?;
+    let mut pos = 0;
+    // Tar headers are always 512 bytes in length.
+    const HEADER_LEN: usize = 512;
+    while pos < input.len() {
+        // Consume `HEADER_LEN` bytes and parse them as a `tar::Header`.
+        debug_assert_eq!(pos % HEADER_LEN, 0);
+        let header_start = pos;
+        pos = pos.checked_add(HEADER_LEN)
+            .ok_or_else(|| io::Error::other(format!("pos overflow: {pos} + {HEADER_LEN}")))?;
+        let header_end = pos;
+        let header_bytes = input.get(header_start .. header_end)
+            .ok_or_else(|| io::Error::other(format!(
+                "not enough bytes for header: end {header_end} >= len {}", input.len())))?;
+        // "The end of an archive is marked by at least two consecutive zero-filled records."  We
+        // just skip all-zero headers, and stop upon reaching the end of the file.
+        if header_bytes.iter().all(|&b| b == 0) {
+            continue;
+        }
+        let header = tar::Header::from_byte_slice(header_bytes);
+
+        let path = header.path()?;
+
+        let size = header.size()?;
+        let entry_size = header.entry_size()?;
+        if entry_size != size {
+            return Err(io::Error::other(format!("sparse files are not supported: \
+                size {size} != entry_size {entry_size}, for {path:?}")).into());
+        }
+        let size = usize::try_from(size)
+            .map_err(|_| io::Error::other(format!("size {size} for {path:?} is out of range")))?;
+        let data_start = pos;
+        let data_end = data_start.checked_add(size)
+            .ok_or_else(|| io::Error::other(format!(
+                "size overflow for {path:?}: {data_start} + {size}")))?;
+        // Entries are padded to a multiple of 512.
+        let padded_size = size.checked_next_multiple_of(HEADER_LEN)
+            .ok_or_else(|| io::Error::other(format!("size {size} for {path:?} is out of range")))?;
+        pos = pos.checked_add(padded_size)
+            .ok_or_else(|| io::Error::other(format!("pos overflow: {pos} + {padded_size}")))?;
+
+        let data_bytes = input.get(data_start .. data_end)
+            .ok_or_else(|| io::Error::other(format!(
+                "not enough bytes for file {path:?}: end {data_end} >= len {}", input.len())))?;
+
         if path == Path::new("index.cbor") {
             assert!(index.is_none(), "duplicate crate.json in archive?");
-            index = Some(serde_cbor::from_reader(entry)?);
+            index = Some(serde_cbor::from_slice(data_bytes)?);
         } else if path == Path::new("crate.json") {
             assert!(json_offset.is_none(), "duplicate crate.json in archive?");
-            assert!(entry.header().size()? == entry.header().entry_size()?,
-                "crate.json is a sparse file (unsupported)");
-            json_offset = Some(entry.raw_file_position());
+            json_offset = Some(data_start);
         }
     }
 
-    let index = index.unwrap_or_else(|| panic!("index.cbor not found in archive"));
-    let json_offset = json_offset.unwrap_or_else(|| panic!("crate.json not found in archive"));
+    let index = index
+        .ok_or_else(|| io::Error::other("index.cbor not found in archive"))?;
+    let json_offset = json_offset
+        .ok_or_else(|| io::Error::other("crate.json not found in archive"))?;
 
     Ok((index, json_offset))
 }

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::io::{self, Read, Write, Seek, SeekFrom};
+use std::io::{self, Write};
 
 use serde_cbor;
 use serde_json;
@@ -8,12 +8,12 @@ use crate::lib_util::{self, CrateIndex, InternTable, EntryKind, StringId};
 use crate::schema_ver::SCHEMA_VER;
 
 
-fn read_crates<R: Read + Seek>(
-    inputs: &mut [R],
-) -> serde_cbor::Result<(Vec<CrateIndex>, Vec<u64>)> {
+fn read_crates(
+    inputs: &[impl AsRef<[u8]>],
+) -> serde_cbor::Result<(Vec<CrateIndex>, Vec<usize>)> {
     let mut indexes = Vec::with_capacity(inputs.len());
     let mut json_offsets = Vec::with_capacity(inputs.len());
-    for r in inputs.iter_mut() {
+    for r in inputs {
         let (i, j) = lib_util::read_crate_index(r)?;
         indexes.push(i);
         json_offsets.push(j);
@@ -89,8 +89,8 @@ fn check_matching_versions(indexes: &[CrateIndex]) -> serde_cbor::Result<()> {
 }
 
 /// Combine the contents of `ocs`, producing a combined JSON crate data object as the result.
-pub fn link_crates<R, W>(inputs: &mut [R], mut output: W) -> serde_cbor::Result<()>
-where R: Read + Seek, W: Write {
+pub fn link_crates<W>(inputs: &[impl AsRef<[u8]>], mut output: W) -> serde_cbor::Result<()>
+where W: Write {
     let (indexes, json_offsets) = read_crates(inputs)?;
     let (it, defs, translate) = assign_global_ids(&indexes);
     let (roots, tests) = collect_roots(&indexes, &translate);
@@ -155,9 +155,9 @@ where R: Read + Seek, W: Write {
                 write!(output, ",")?;
             }
 
-            let input = &mut inputs[crate_num];
-            input.seek(SeekFrom::Start(offset))?;
-            io::copy(&mut input.take(len), &mut output)?;
+            let input = inputs[crate_num].as_ref();
+            let chunk = &input[offset .. offset + len];
+            output.write_all(chunk)?;
         }
         write!(output, "]")?;
     }
@@ -188,8 +188,8 @@ where R: Read + Seek, W: Write {
     Ok(())
 }
 
-pub fn gather_calls<R: Read + Seek>(
-    inputs: &mut [R],
+pub fn gather_calls(
+    inputs: &[impl AsRef<[u8]>],
 ) -> serde_cbor::Result<(InternTable, Vec<(StringId, StringId)>)> {
     let (indexes, _json_offsets) = read_crates(inputs)?;
     let (it, defs, translate) = assign_global_ids(&indexes);


### PR DESCRIPTION
There were previously several issues with the way `mir-json-dce` handled the input `.mir` files:

* The initial read of the tar (`.mir`) file tried to skip over the `crate.json` entry, but the `tar` library we use cannot seek past an entry, so the data would be read and then discarded.
* `index.cbor` was being read a few bytes at a time, with no buffering (evident when running `strace mir-json-dce foo.mir`)
* JSON chunks were being read one at a time, with buffering on the output side but not on the input.  This means one OS-level read operation for every item in every table of the final output.

This branch changes the behavior of `mir-json-dce` to read the entire `.mir` file into memory, so no further read operations are needed when reading the tar headers, parsing `index.cbor`, or copying JSON chunks to the output.  This gives about a 3x speedup when running `mir-json-dce` in isolation, and reduces the running time of the crux-mir test suite (with no cached `.mir` files) from 15 minutes to 10 minutes on my machine.