### PR TITLE
emit intrinsic fallback bodies

### DIFF
--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -1106,14 +1106,28 @@ fn emit_instance<'tcx>(
                             return Ok(());
                         }
                     }
+                    ty_inst
                 },
-                // These variants are unsupported by the `mir_shims` query, which backs
+                // Virtual shims are unsupported by the `mir_shims` query, which backs
                 // `instance_mir`.
-                ty::InstanceKind::Virtual(..) |
-                ty::InstanceKind::Intrinsic(..) => return Ok(()),
-                _ => {},
+                ty::InstanceKind::Virtual(..) => return Ok(()),
+                // Intrinsics are also unsupported by `instance_mir`, but for intrinsics that have
+                // fallback bodies, we can use a fake `InstanceKind::Item` to get it to emit the
+                // intrinsic as a normal function using the fallback body.
+                ty::InstanceKind::Intrinsic(def_id) => {
+                    let Some(intrin) = tcx.intrinsic(def_id) else { return Ok(()) };
+                    if intrin.must_be_overridden {
+                        // `must_be_overridden` means the intrinsic has no fallback body.
+                        return Ok(());
+                    }
+                    // Same as `ty_inst`, but replace `InstanceKind::Intrinsic` with `Item`.
+                    ty::Instance {
+                        def: ty::InstanceKind::Item(def_id),
+                        args: ty_inst.args,
+                    }
+                },
+                _ => ty_inst,
             }
-            ty_inst
         },
         // We don't generate MIR for `ClosureFnPointer` shims.  Instead, we generate code in
         // crucible-mir to implement this shim.


### PR DESCRIPTION
Some intrinsics have simplified implementations in terms of other Rust features, which could be useful for verification ([source](https://doc.rust-lang.org/1.91.1/unstable-book/language-features/intrinsics.html#intrinsics-with-fallback-logic)):

> Many intrinsics can be written in pure rust, albeit inefficiently or without supporting some features that only exist on some backends. Backends can simply not implement those intrinsics without causing any code miscompilations or failures to compile.

mir-json previously exported these bodies, but after upgrading from nightly-2025-09-14 to nightly-2026-03-21, it no longer does.  The older nightly used `InstanceKind::Item` for intrinsics with bodies and `InstanceKind::Intrinsic` for those without, while the newer one uses `Intrinsic` for all intrinsics, which causes mir-json to skip emitting the function.

This branch restores output of intrinsic fallback bodies by switching from `InstanceKind::Intrinsic` to `InstanceKind::Item` when it detects that the intrinsic has a body.  This is probably not an intended use of `Instance` or `tcx.instance_mir`, but it seems to work.