### PR TITLE
Update schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
     - name: Validate schema
       env:
-        VER: 1.1
+        VER: 1.2
         OS_TAG: ${{ matrix.os }}
         ARCH_TAG: ${{ runner.arch }}
       run: .github/ci.sh validate_json_schema

--- a/SCHEMA_CHANGELOG.md
+++ b/SCHEMA_CHANGELOG.md
@@ -3,6 +3,16 @@ The following document describes the changes to the JSON schema that
 as a changelog for the code in the `mir-json` tools themselves, which are
 versioned separately.)
 
+## 12
+
+  * Instance: `CloneShim.callees` is now emitted as `Ty?[]`.
+    Elements are `null` when instance resolution yielded no callee.
+  * Variant: the `discr` field has been **removed** from variant output.
+  * Operand: New variant `RuntimeChecks`.
+  * InlineType: New variant `Pat`.
+  * CastKind: New nullary variant `Subtype`.
+  * `PointerCoercion.ClosureFnPointer` now has a `safety` field
+
 ## 11
 
 Add `size` and `align` fields to `dyn Trait` vtables.

--- a/SCHEMA_CHANGELOG.md
+++ b/SCHEMA_CHANGELOG.md
@@ -5,8 +5,7 @@ versioned separately.)
 
 ## 12
 
-  * Instance: `CloneShim.callees` is now emitted as `Ty?[]`.
-    Elements are `null` when instance resolution yielded no callee.
+  * Instance: `ClosureShim` has been renamed to `CloneShim`.
   * Variant: the `discr` field has been **removed** from variant output.
   * Operand: New variant `RuntimeChecks`.
   * InlineType: New variant `Pat`.

--- a/doc/mir-json-schema.ts
+++ b/doc/mir-json-schema.ts
@@ -5,7 +5,7 @@
 
 /// The MIR JSON format
 type MIR = {
-  version: 7,
+  version: 11,
   fns: Fn[],
   adts: Adt[],
   statics: Static[],
@@ -36,11 +36,17 @@ type Fn = {
   return_ty: Ty
 }
 
-/// Calling convention for this function
-type Abi = {
-  kind: string,
-  ...
-}
+/// Calling convention for this function.
+type Abi =
+    { kind: "Rust" | "RustCall" | "RustCold" | "RustPreserveNone"
+          | "RustInvalid" | "Unadjusted" | "Custom"
+          | "PtxKernel" | "Msp430Interrupt" | "X86Interrupt" | "GpuKernel"
+          | "EfiApi" | "AvrInterrupt" | "AvrNonBlockingInterrupt"
+          | "CmseNonSecureCall" | "CmseNonSecureEntry"
+          | "RiscvInterruptM" | "RiscvInterruptS" }
+  | { kind: "C" | "Cdecl" | "Stdcall" | "Fastcall" | "Vectorcall" | "Thiscall"
+          | "Aapcs" | "Win64" | "SysV64" | "System",
+      unwind: boolean }
 
 type FnSig = {
   inputs: Ty[],
@@ -57,9 +63,9 @@ type Var = {
   ty: Ty
 }
 
-/// Mutability setttings
+/// Mutability settings
 type Mutability = {
-  kind: "MutMutable" | "Mut" | "MutImmutable" | "Not"
+  kind: "Mut" | "Not"
 }
 
 /// Implementation of a Rust function
@@ -104,16 +110,11 @@ type AdtKind =
 
 type Variant = {
   name: DefId,
-  discr: VariantDiscr,
   fields: Field[],
   ctor_kind: CtorKind?,
   discr_value: string?,
   inhabited: boolean
 }
-
-type VariantDiscr =
-    { kind: "Explicit", name: DefId }
-  | { kind: "Relative", index: number }
 
 type Field = {
   name: DefId,
@@ -142,7 +143,8 @@ type NamedTy = {
 }
 
 type InlineType =
-    { kind: "Bool" | "Char" | "Str" | "Never" | "Foreign" | "CoroutineWitness" }
+    { kind: "Bool" | "Char" | "Str" | "Never" | "Foreign" | "CoroutineWitness"
+          | "Error" | "Infer" | "Bound" | "Placeholder" | "Alias" }
   | { kind: "Int", intkind: BaseSize }
   | { kind: "Uint", uintkind: BaseSize }
   | { kind: "Tuple", tys: Ty[] }
@@ -154,11 +156,12 @@ type InlineType =
   | { kind: "Coroutine", discr_ty: Ty, upvar_tys: Ty[], saved_tys: Ty[], field_map: number[][] }
   | { kind: "CoroutineClosure", upvar_tys: Ty[] }
   | { kind: "FnPtr", signature: FnSig }
-  | { kind: "Dynamic", trait_id: DefId, predicates: any[] }
+  | { kind: "Dynamic", trait_id: DefId, predicates: Predicate[] }
   | { kind: "RawPtr", ty: Ty, mutability: Mutability }
   | { kind: "Float", size: FloatKind }
   | { kind: "Slice", ty: Ty }
   | { kind: "Const", constant: ConstVal }
+  | { kind: "Pat", ty: Ty }
   | { kind: "Unsupported" }
 
 type BaseSize = {
@@ -166,12 +169,19 @@ type BaseSize = {
         "Isize" | "I8" | "I16" | "I32" | "I64" | "I128"
 }
 
-type FloatKind = { kind: "F32" | "F64" }
+type FloatKind = { kind: "F16" | "F32" | "F64" | "F128" }
+
+/// A predicate appearing in a `dyn Trait` existential.
+type Predicate =
+    { kind: "Trait", trait: DefId, args: Ty[] }
+  | { kind: "Projection", proj: DefId, args: Ty[], rhs_ty: Ty }
+  | { kind: "Projection_Const" }
+  | { kind: "AutoTrait", trait: DefId }
 
 type Layout = {
   align: number,
   size: number,
-  field_offsets?: number[]
+  field_offsets: number[]?
 }
 
 
@@ -182,13 +192,9 @@ type Layout = {
 // -----------------------------------------------------------------------------
 
 /// Globals
-type Static = {
-  kind: "constant" | "body",
-  name: DefId,
-  ty: Ty,
-  mutable: boolean,
-  rendered?: ConstVal
-}
+type Static =
+    { kind: "constant", name: DefId, ty: Ty, mutable: boolean, rendered: ConstVal }
+  | { kind: "body",     name: DefId, ty: Ty, mutable: boolean }
 
 
 // -----------------------------------------------------------------------------
@@ -246,12 +252,12 @@ type Intrinsic = {
 }
 
 type Instance =
-   { kind: "Item" | "Intrinsic" | "VtableShim" | "ReifyShim", def_id: DefId, args: Ty[] }
+   { kind: "Item" | "Intrinsic" | "VTableShim" | "ReifyShim", def_id: DefId, args: Ty[] }
  | { kind: "FnPtrShim", ty: Ty, def_id: DefId, args: Ty[] }
  | { kind: "Virtual", trait_id: DefId, index: number, item_id: DefId }
  | { kind: "ClosureOnceShim", call_once: DefId, args: Ty[] }
- | { kind: "DropGlue", ty: Ty?, def_id: DefId, args: Ty?[] }
- | { kind: "ClosureShim", ty: Ty, callees: DefId[], def_id: DefId, args: Ty[] }
+ | { kind: "DropGlue", ty: Ty?, def_id: DefId, args: Ty[] }
+ | { kind: "CloneShim", ty: Ty, callees: DefId?[], def_id: DefId, args: Ty[] }
  | { kind: "ClosureFnPointerShim", call_mut: DefId }
  | { kind: "Unsupported" }
 
@@ -260,13 +266,7 @@ type Instance =
 // Constants
 // -----------------------------------------------------------------------------
 
-type Constant =
-    { rendered: ConstVal, ty: Ty }
-  | { initializer: RustConstInitializer, ty: Ty }
-
-type RustConstInitializer = {
-  def_id: DefId
-}
+type Constant = { rendered: ConstVal, ty: Ty }
 
 type ConstVal =
     { kind: "isize", size: number,             val: string }
@@ -313,28 +313,23 @@ type PlaceElem =
   | { kind: "ConstantIndex", offset: number, min_length: number, from_end: boolean }
   | { kind: "Subslice", from: number, to: number, from_end: boolean }
   | { kind: "Downcast", variant: number }
-  | { kind: "Subtype", ty: Ty }
+  | { kind: "OpaqueCast", variant: Ty }
+  | { kind: "UnwrapUnsafeBinder", ty: Ty }
 
 type Rvalue =
     { kind: "Use", usevar: Operand }
   | { kind: "Repeat", op: Operand, len: number }
   | { kind: "Ref", borrowkind: BorrowKind, refvar: Lvalue, region: string }
   | { kind: "AddressOf", mutbl: Mutability, place: Lvalue }
-  | { kind: "Len", lv: Lvalue }
   | { kind: "Cast", type: CastKind, op: Operand, ty: Ty }
   | { kind: "BinaryOp", op: BinOp, L: Operand, R: Operand }
-  | { kind: "NullaryOp", op: NullOp, ty: Ty }
   | { kind: "UnaryOp", uop: UnOp, op: Operand }
   | { kind: "Discriminant", val: Lvalue, ty: Ty }
   | { kind: "Aggregate", akind: AggregateKind, ops: Operand[] }
   | { kind: "AdtAg", ag: AdtAg }
-  | { kind: "ShallowInitBox", ptr: Operand, ty: Ty }
   | { kind: "CopyForDeref", place: Lvalue }
   | { kind: "ThreadLocalRef", def_id: DefId, ty: Ty }
-
-type NullOp = {
-  kind: "SizeOf" | "AlignOf" | "UbChecks"
-}
+  | { kind: "WrapUnsafeBinder", op: Operand, ty: Ty }
 
 type UnOp = {
   kind: "Not" | "Neg" | "PtrMetadata"
@@ -364,6 +359,11 @@ type Operand =
     { kind: "Move", data: Lvalue }
   | { kind: "Constant", data: Constant }
   | { kind: "Copy", data: Lvalue }
+  | { kind: "RuntimeChecks", data: RuntimeChecks }
+
+type RuntimeChecks = {
+  kind: "UbChecks" | "ContractChecks" | "OverflowChecks"
+}
 
 type AggregateKind =
     { kind: "Array", ty: Ty }
@@ -371,29 +371,34 @@ type AggregateKind =
   | { kind: "Coroutine", discr_ty: Ty, upvar_tys: Ty[], saved_tys: Ty[], field_map: number[][] }
   | { kind: "RawPtr", ty: Ty, mutbl: Mutability }
 
-type BorrowKind = "Shared" | "Unique" | "Mut"
+type BorrowKind = "Shared" | "Mut"
 
 type CastKind =
       { kind: "PointerExposeProvenance"
             | "PointerWithExposedProvenance"
-            | "DynStar"
             | "IntToInt"
             | "FloatToInt"
             | "FloatToFloat"
             | "IntToFloat"
             | "PtrToPtr"
             | "FnPtrToPtr"
-            | "Transmute" }
+            | "Transmute"
+            | "Subtype" }
     | { kind: "PointerCoercion",
-        origin: any,
-        cast: { kind: "ReifyFnPointer"
-                    | "UnsafeFnPointer"
-                    | "MutToConstPointer"
-                    | "ArrayToPointer"
-                    | "Unsize" }
+        origin: CoercionSource,
+        cast: PointerCoercion
       }
     | { kind: "UnsizeVtable", vtable: DefId }
     | { kind: "ClosureFnPointer", shim: DefId }
+
+type PointerCoercion =
+    { kind: "ReifyFnPointer" | "UnsafeFnPointer"
+          | "MutToConstPointer" | "ArrayToPointer" | "Unsize" }
+  | { kind: "ClosureFnPointer", safety: Safety }
+
+type Safety = { kind: "Safe" | "Unsafe" }
+
+type CoercionSource = { kind: "AsCast" | "Implicit" }
 
 
 // -----------------------------------------------------------------------------
@@ -406,19 +411,26 @@ type Statement =
   | { kind: "StorageLive", slvar: Var, pos: string }
   | { kind: "StorageDead", sdvar: Var, pos: string }
   | { kind: "Nop", pos: string }
-  | { kind: "Deinit", pos: string }
   | { kind: "ConstEvalCounter", pos: string }
+  | { kind: "FakeRead", pos: string }
+  | { kind: "Retag", pos: string }
+  | { kind: "PlaceMention", lvalue: Lvalue, pos: string }
+  | { kind: "AscribeUserType", pos: string }
+  | { kind: "Coverage", pos: string }
+  | { kind: "BackwardIncompatibleDropHint", pos: string }
   | { kind: "Intrinsic", intrinsic_kind: "Assume", operand: Operand, pos: string }
   | { kind: "Intrinsic", intrinsic_kind: "CopyNonOverlapping", src: Operand, dst: Operand, count: Operand, pos: string }
 
 type Terminator =
     { kind: "Goto", target: BasicBlockInfo, pos: string }
-  | { kind: "SwitchInt", discr: Operand, switch_ty: Ty, values: string?[], targets: BasicBlockInfo[], pos: string }
-  | { kind: "Resume" | "Abort" | "Return" | "Unreachable" | "InlineAsm", pos: string }
+  | { kind: "SwitchInt", discr: Operand, switch_ty: Ty, values: string[], targets: BasicBlockInfo[], pos: string }
+  | { kind: "Resume" | "Abort" | "Return" | "Unreachable"
+          | "InlineAsm" | "Yield" | "FalseEdge" | "FalseUnwind"
+          | "CoroutineDrop", pos: string }
   | { kind: "Drop", location: Lvalue, target: BasicBlockInfo, drop_fn: string?, pos: string }
   | { kind: "Call", func: Operand, args: Operand[], destination: [Lvalue,BasicBlockInfo]?, pos: string }
   | { kind: "Assert", cond: Operand, expected: boolean, msg: string, target: BasicBlockInfo, pos: string }
-  | { kind: "Unsupported" }
+  | { kind: "Unsupported", pos: string }
 
 
 

--- a/doc/mir-json-schema.ts
+++ b/doc/mir-json-schema.ts
@@ -257,7 +257,7 @@ type Instance =
  | { kind: "Virtual", trait_id: DefId, index: number, item_id: DefId }
  | { kind: "ClosureOnceShim", call_once: DefId, args: Ty[] }
  | { kind: "DropGlue", ty: Ty?, def_id: DefId, args: Ty[] }
- | { kind: "CloneShim", ty: Ty, callees: DefId?[], def_id: DefId, args: Ty[] }
+ | { kind: "CloneShim", ty: Ty, callees: DefId[], def_id: DefId, args: Ty[] }
  | { kind: "ClosureFnPointerShim", call_mut: DefId }
  | { kind: "Unsupported" }
 

--- a/doc/mir-json-schema.ts
+++ b/doc/mir-json-schema.ts
@@ -5,7 +5,7 @@
 
 /// The MIR JSON format
 type MIR = {
-  version: 11,
+  version: 12,
   fns: Fn[],
   adts: Adt[],
   statics: Static[],

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -429,22 +429,22 @@ impl<'tcx> ToJson<'tcx> for ty::Instance<'tcx> {
                 };
                 let callees = sub_tys.into_iter()
                     .map(|ty| {
-                        let inst = ty::Instance::try_resolve(
+                        let mb_inst = ty::Instance::try_resolve(
                             mir.tcx,
                             ty::TypingEnv::fully_monomorphized(),
                             did,
                             mir.tcx.mk_args(&[ty.into()]),
-                        ).unwrap_or_else(|_| {
-                            panic!("failed to resolve instance: {:?}, {:?}", did, ty);
-                        });
-                        if let Some(inst) = inst {
-                            // Add the callee to `used.insances`, so we'll emit code for it even if
-                            // it's otherwise unused.  If `inst` is itself a `CloneShim`, its own
-                            // callees will be visited when generating the "intrinsics" entry for
-                            // `inst`.
-                            mir.used.instances.insert(inst.clone().into());
-                        }
-                        inst.map(|i| inst_id_str(mir.tcx, i))
+                        );
+                        let inst = match mb_inst {
+                            Ok(Some(inst)) => inst,
+                            _ => panic!("failed to resolve instance: {:?}, {:?}", did, ty),
+                        };
+                        // Add the callee to `used.instances`, so we'll emit code for it even if
+                        // it's otherwise unused.  If `inst` is itself a `CloneShim`, its own
+                        // callees will be visited when generating the "intrinsics" entry for
+                        // `inst`.
+                        mir.used.instances.insert(inst.clone().into());
+                        inst_id_str(mir.tcx, inst)
                     }).collect::<Vec<_>>();
                 json!({
                     "kind": "CloneShim",

--- a/src/schema_ver.rs
+++ b/src/schema_ver.rs
@@ -6,4 +6,4 @@
 /// Each version of the schema is assumed to be backwards-incompatible with
 /// previous versions of the schema. As such, any time this version number is
 /// bumped, it should be treated as a major version bump.
-pub const SCHEMA_VER: u64 = 11;
+pub const SCHEMA_VER: u64 = 12;


### PR DESCRIPTION
We haven't been updating the machine schema, so this hopefully catches it up with what the source currently emits.

Fixes #296 by making CI use version 1.2 of `simple-json-schema` which returns an error code if schema validation fails.