### PR TITLE
Track crate SVH hashes in MIR

### DIFF
--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -1369,6 +1369,70 @@ pub struct AnalysisData<O> {
     pub output: O,
 }
 
+/*
+Note [CrateDepKind::MacrosOnly]
+~~~~~~~~~~~~~~~~~~~~~
+In what follows, we store the crate dependencies of the current crate for later linker 
+related validation and exclude crates flagged as CrateDepKind::MacrosOnly.
+The CrateDepKind enum has some misleading documentation about what is considered a 
+CrateDepKind::MacrosOnly crate. The documentation says:
+
+    "A dependency that is only used for its macros."
+
+This is actually slightly inaccurate. CrateDepKind::MacrosOnly is dedicated to proc_macro crates,
+rather than other crates where the user only imports macros, those being flagged as CrateDepKind::Unconditional. 
+
+In order to test this, we created a crate called hello_world that looked like this:
+
+```
+#[macro_export]
+macro_rules! foo {
+    ($msg:expr) => {
+        $msg
+    };
+}
+
+pub fn add_one(x: usize) -> usize{
+    return x + 1;
+}
+```
+
+Then I added the following to crux-mir's example-1:
+
+```
+use hello_world::foo;
+
+/// Find-first-set (fast implementation)
+pub fn ffs_fast(mut i: u32) -> u32 {
+    foo!("hello");
+    let mut n = 1;
+    if (i & 0xffff) == 0 { n += 16; i >>= 16; }
+    if (i & 0x00ff) == 0 { n +=  8; i >>=  8; }
+    if (i & 0x000f) == 0 { n +=  4; i >>=  4; }
+    if (i & 0x0003) == 0 { n +=  2; i >>=  2; }
+    if i != 0 {
+        return n + ((i.wrapping_add(1)) & 0x01);
+    } else {
+        return 0;
+    }
+}
+
+/// Find-first-set (reference implementation)
+pub fn ffs_ref(word: u32) -> u32 {
+    foo!("hello");
+    for i in 0 .. 32 {
+        if word & (1 << i) != 0 {
+            return i + 1;
+        }
+    }
+    return 0;
+}
+```
+The hello_world crate was flagged as CrateDepKind::Unconditional by the function below.
+For more information on why we exclude proc_macro crates to begin with, please checkou the
+note over lib_util::check_dependencies.
+*/
+
 /// Analyze the crate currently being compiled.  Returns `Ok(Some(data))` upon successfully writing
 /// the crate MIR, returns `Ok(None)` when there is no need to write out MIR (namely, when `comp`
 /// is not producing an `Exe` output), and returns `Err(e)` on I/O or serialization errors.

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -12,7 +12,7 @@ use rustc_session::config::{OutputType, OutFileName};
 use rustc_span::Span;
 use rustc_span::symbol::{Symbol, Ident};
 use rustc_abi::{self, ExternAbi};
-use std::collections::HashMap;
+use std::collections::{HashSet};
 use std::fmt::Write as FmtWrite;
 use std::io;
 use std::iter;
@@ -1367,7 +1367,7 @@ pub struct AnalysisData<O> {
     pub mir_path: PathBuf,
     pub extern_mir_paths: Vec<PathBuf>,
     pub output: O,
-    pub svh_hashes: Option<HashMap<String, String>>
+    pub svh_hashes: Option<HashSet<(String, String)>>
 }
 
 /// Analyze the crate currently being compiled.  Returns `Ok(Some(data))` upon successfully writing
@@ -1398,11 +1398,11 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
     };
     let mut out = mk_output(&mir_path)?;
 
-    let mut svh_hashes = HashMap::new();
+    let mut svh_hashes = HashSet::new();
     for &cnum in tcx.crates(()) {
-        svh_hashes.insert(
+        svh_hashes.insert((
             tcx.crate_name(cnum).to_string(),
-            tcx.crate_hash(cnum).to_string() 
+            tcx.crate_hash(cnum).to_string() )
         );
 
         let src = tcx.used_crate_source(cnum);

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -1403,10 +1403,13 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
 
     let mut dep_hashes = HashSet::new();
     for &cnum in tcx.crates(()) {
-        dep_hashes.insert(SvhHash::new(
+
+        // Exclude proc_macro crates
+        if ! tcx.crate_dep_kind(cnum).macros_only(){        
+            dep_hashes.insert(SvhHash::new(
             tcx.crate_name(cnum).to_string(),
-            tcx.crate_hash(cnum).to_string() )
-        );
+            tcx.crate_hash(cnum).to_string())
+        );}
 
         let src = tcx.used_crate_source(cnum);
         let it = src.dylib.iter()

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -12,6 +12,7 @@ use rustc_session::config::{OutputType, OutFileName};
 use rustc_span::Span;
 use rustc_span::symbol::{Symbol, Ident};
 use rustc_abi::{self, ExternAbi};
+use std::collections::HashMap;
 use std::fmt::Write as FmtWrite;
 use std::io;
 use std::iter;
@@ -1366,6 +1367,7 @@ pub struct AnalysisData<O> {
     pub mir_path: PathBuf,
     pub extern_mir_paths: Vec<PathBuf>,
     pub output: O,
+    pub svh_hashes: Option<HashMap<String, String>>
 }
 
 /// Analyze the crate currently being compiled.  Returns `Ok(Some(data))` upon successfully writing
@@ -1396,7 +1398,13 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
     };
     let mut out = mk_output(&mir_path)?;
 
+    let mut svh_hashes = HashMap::new();
     for &cnum in tcx.crates(()) {
+        svh_hashes.insert(
+            tcx.crate_name(cnum).to_string(),
+            tcx.crate_hash(cnum).to_string() 
+        );
+
         let src = tcx.used_crate_source(cnum);
         let it = src.dylib.iter()
             .chain(src.rlib.iter())
@@ -1451,7 +1459,7 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
     // references them, but we check again here just in case.
     emit_new_defs(&mut ms, &mut out)?;
 
-    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: out }))
+    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: out, svh_hashes: Some(svh_hashes) }))
 }
 
 pub fn analyze_nonstreaming<'tcx>(
@@ -1459,7 +1467,7 @@ pub fn analyze_nonstreaming<'tcx>(
     export_style: ExportStyle,
 ) -> Result<Option<AnalysisData<()>>, serde_cbor::Error> {
     let opt_ad = analyze_inner(tcx, export_style, |_| { Ok(lib_util::Output::default()) })?;
-    let AnalysisData { mir_path, extern_mir_paths, output: out } = match opt_ad {
+    let AnalysisData { mir_path, extern_mir_paths, output: out, svh_hashes } = match opt_ad {
         Some(x) => x,
         None => return Ok(None),
     };
@@ -1481,9 +1489,9 @@ pub fn analyze_nonstreaming<'tcx>(
     tcx.sess.dcx().note(
         format!("Indexing MIR ({} items)...", total_items));
     let file = File::create(&mir_path)?;
-    lib_util::write_indexed_crate(file, &j)?;
+    lib_util::write_indexed_crate(file, &j, svh_hashes.unwrap())?;
 
-    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: () }))
+    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: (), svh_hashes: None}))
 }
 
 pub fn analyze_streaming<'tcx>(
@@ -1491,12 +1499,12 @@ pub fn analyze_streaming<'tcx>(
     export_style: ExportStyle,
 ) -> Result<Option<AnalysisData<()>>, serde_cbor::Error> {
     let opt_ad = analyze_inner(tcx, export_style, lib_util::start_streaming)?;
-    let AnalysisData { mir_path, extern_mir_paths, output } = match opt_ad {
+    let AnalysisData { mir_path, extern_mir_paths, output, svh_hashes } = match opt_ad {
         Some(x) => x,
         None => return Ok(None),
     };
-    lib_util::finish_streaming(output)?;
-    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: () }))
+    lib_util::finish_streaming(output, svh_hashes.unwrap())?;
+    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: () , svh_hashes: None}))
 }
 
 pub use self::analyze_streaming as analyze;

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -1466,9 +1466,10 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
     let mut dep_hashes = HashSet::new();
     for &cnum in tcx.crates(()) {
         // Exclude proc_macro crates from the hashset of dependencies.
-        // See note above for more info.
-        if ! tcx.crate_dep_kind(cnum).macros_only(){        
-            dep_hashes.insert(UniqueCrateId::new( tcx, cnum));}
+        // See Note [CrateDepKind::MacrosOnly].
+        if !tcx.crate_dep_kind(cnum).macros_only() {        
+            dep_hashes.insert(UniqueCrateId::new(tcx, cnum));
+        }
 
         let src = tcx.used_crate_source(cnum);
         let it = src.dylib.iter()

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -26,7 +26,7 @@ mod to_json;
 mod ty_json;
 use analyz::to_json::*;
 use analyz::ty_json::*;
-use lib_util::{self, JsonOutput, EntryKind};
+use lib_util::{self, JsonOutput, EntryKind, SvhHash};
 use schema_ver::SCHEMA_VER;
 
 use log::debug;
@@ -1367,7 +1367,8 @@ pub struct AnalysisData<O> {
     pub mir_path: PathBuf,
     pub extern_mir_paths: Vec<PathBuf>,
     pub output: O,
-    pub svh_hashes: Option<HashSet<(String, String)>>
+    pub root_hash: Option<SvhHash>,
+    pub dep_hashes: Option<HashSet<SvhHash>>
 }
 
 /// Analyze the crate currently being compiled.  Returns `Ok(Some(data))` upon successfully writing
@@ -1397,10 +1398,12 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
         },
     };
     let mut out = mk_output(&mir_path)?;
+    let root_hash = SvhHash::new(tcx.crate_name(LOCAL_CRATE).to_string(),tcx.crate_hash(LOCAL_CRATE).to_string());
 
-    let mut svh_hashes = HashSet::new();
+
+    let mut dep_hashes = HashSet::new();
     for &cnum in tcx.crates(()) {
-        svh_hashes.insert((
+        dep_hashes.insert(SvhHash::new(
             tcx.crate_name(cnum).to_string(),
             tcx.crate_hash(cnum).to_string() )
         );
@@ -1459,7 +1462,7 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
     // references them, but we check again here just in case.
     emit_new_defs(&mut ms, &mut out)?;
 
-    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: out, svh_hashes: Some(svh_hashes) }))
+    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: out, dep_hashes: Some(dep_hashes), root_hash: Some(root_hash) }))
 }
 
 pub fn analyze_nonstreaming<'tcx>(
@@ -1467,7 +1470,7 @@ pub fn analyze_nonstreaming<'tcx>(
     export_style: ExportStyle,
 ) -> Result<Option<AnalysisData<()>>, serde_cbor::Error> {
     let opt_ad = analyze_inner(tcx, export_style, |_| { Ok(lib_util::Output::default()) })?;
-    let AnalysisData { mir_path, extern_mir_paths, output: out, svh_hashes } = match opt_ad {
+    let AnalysisData { mir_path, extern_mir_paths, output: out, dep_hashes, root_hash } = match opt_ad {
         Some(x) => x,
         None => return Ok(None),
     };
@@ -1489,9 +1492,9 @@ pub fn analyze_nonstreaming<'tcx>(
     tcx.sess.dcx().note(
         format!("Indexing MIR ({} items)...", total_items));
     let file = File::create(&mir_path)?;
-    lib_util::write_indexed_crate(file, &j, svh_hashes.unwrap())?;
+    lib_util::write_indexed_crate(file, &j, dep_hashes.unwrap(), root_hash.unwrap())?;
 
-    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: (), svh_hashes: None}))
+    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: (), dep_hashes: None, root_hash: None}))
 }
 
 pub fn analyze_streaming<'tcx>(
@@ -1499,13 +1502,14 @@ pub fn analyze_streaming<'tcx>(
     export_style: ExportStyle,
 ) -> Result<Option<AnalysisData<()>>, serde_cbor::Error> {
     let opt_ad = analyze_inner(tcx, export_style, lib_util::start_streaming)?;
-    let AnalysisData { mir_path, extern_mir_paths, output, svh_hashes } = match opt_ad {
+    let AnalysisData { mir_path, extern_mir_paths, output, dep_hashes, root_hash } = match opt_ad {
         Some(x) => x,
         None => return Ok(None),
     };
-    lib_util::finish_streaming(output, svh_hashes.unwrap())?;
-    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: () , svh_hashes: None}))
+    lib_util::finish_streaming(output, dep_hashes.unwrap(), root_hash.unwrap())?;
+    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: () , dep_hashes: None, root_hash: None}))
 }
+
 
 pub use self::analyze_streaming as analyze;
 pub use analyz::to_json::ExportStyle;

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -26,7 +26,7 @@ mod to_json;
 mod ty_json;
 use analyz::to_json::*;
 use analyz::ty_json::*;
-use lib_util::{self, JsonOutput, EntryKind, SvhHash};
+use lib_util::{self, JsonOutput, EntryKind, UniqueCrateId, CrateDependencies, EmptyCrateDependenciesError};
 use schema_ver::SCHEMA_VER;
 
 use log::debug;
@@ -1367,8 +1367,6 @@ pub struct AnalysisData<O> {
     pub mir_path: PathBuf,
     pub extern_mir_paths: Vec<PathBuf>,
     pub output: O,
-    pub root_hash: Option<SvhHash>,
-    pub dep_hashes: Option<HashSet<SvhHash>>
 }
 
 /// Analyze the crate currently being compiled.  Returns `Ok(Some(data))` upon successfully writing
@@ -1378,12 +1376,12 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
     tcx: TyCtxt<'tcx>,
     export_style: ExportStyle,
     mk_output: F,
-) -> Result<Option<AnalysisData<O>>, serde_cbor::Error> {
+) -> Result<(Option<AnalysisData<O>>, Option<CrateDependencies>), serde_cbor::Error> {
     let mut extern_mir_paths = Vec::new();
 
     let outputs = tcx.output_filenames(());
     if !outputs.outputs.contains_key(&OutputType::Exe) {
-        return Ok(None);
+        return Ok((None, None));
     }
     let out_path = rustc_session::output::out_filename(
         tcx.sess,
@@ -1398,18 +1396,15 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
         },
     };
     let mut out = mk_output(&mir_path)?;
-    let root_hash = SvhHash::new(tcx.crate_name(LOCAL_CRATE).to_string(),tcx.crate_hash(LOCAL_CRATE).to_string());
+    let root_hash = UniqueCrateId::new(tcx,LOCAL_CRATE);
 
 
     let mut dep_hashes = HashSet::new();
     for &cnum in tcx.crates(()) {
-
-        // Exclude proc_macro crates
+        // Exclude proc_macro crates from the hashset of dependencies.
+        // See note above for more info.
         if ! tcx.crate_dep_kind(cnum).macros_only(){        
-            dep_hashes.insert(SvhHash::new(
-            tcx.crate_name(cnum).to_string(),
-            tcx.crate_hash(cnum).to_string())
-        );}
+            dep_hashes.insert(UniqueCrateId::new( tcx, cnum));}
 
         let src = tcx.used_crate_source(cnum);
         let it = src.dylib.iter()
@@ -1464,19 +1459,21 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
     // Any referenced types should normally be emitted immediately after the entry that
     // references them, but we check again here just in case.
     emit_new_defs(&mut ms, &mut out)?;
-
-    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: out, dep_hashes: Some(dep_hashes), root_hash: Some(root_hash) }))
+    let extra_data = CrateDependencies::new(root_hash, dep_hashes);
+    Ok((Some(AnalysisData { mir_path, extern_mir_paths, output: out}), Some(extra_data)))
 }
 
 pub fn analyze_nonstreaming<'tcx>(
     tcx: TyCtxt<'tcx>,
     export_style: ExportStyle,
 ) -> Result<Option<AnalysisData<()>>, serde_cbor::Error> {
-    let opt_ad = analyze_inner(tcx, export_style, |_| { Ok(lib_util::Output::default()) })?;
-    let AnalysisData { mir_path, extern_mir_paths, output: out, dep_hashes, root_hash } = match opt_ad {
+    let (opt_ad, extra_data_option) = analyze_inner(tcx, export_style, |_| { Ok(lib_util::Output::default()) })?;
+    let AnalysisData { mir_path, extern_mir_paths, output: out} = match opt_ad {
         Some(x) => x,
         None => return Ok(None),
     };
+
+    let extra_data= extra_data_option.ok_or(EmptyCrateDependenciesError)?;
 
     let total_items = out.fns.len() + out.adts.len() + out.statics.len() + out.vtables.len() +
         out.traits.len() + out.intrinsics.len();
@@ -1495,24 +1492,25 @@ pub fn analyze_nonstreaming<'tcx>(
     tcx.sess.dcx().note(
         format!("Indexing MIR ({} items)...", total_items));
     let file = File::create(&mir_path)?;
-    lib_util::write_indexed_crate(file, &j, dep_hashes.unwrap(), root_hash.unwrap())?;
+    lib_util::write_indexed_crate(file, &j, extra_data)?;
 
-    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: (), dep_hashes: None, root_hash: None}))
+    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: ()}))
 }
 
 pub fn analyze_streaming<'tcx>(
     tcx: TyCtxt<'tcx>,
     export_style: ExportStyle,
 ) -> Result<Option<AnalysisData<()>>, serde_cbor::Error> {
-    let opt_ad = analyze_inner(tcx, export_style, lib_util::start_streaming)?;
-    let AnalysisData { mir_path, extern_mir_paths, output, dep_hashes, root_hash } = match opt_ad {
+    let (opt_ad, extra_data_option)  = analyze_inner(tcx, export_style, lib_util::start_streaming)?;
+    let AnalysisData { mir_path, extern_mir_paths, output } = match opt_ad {
         Some(x) => x,
         None => return Ok(None),
     };
-    lib_util::finish_streaming(output, dep_hashes.unwrap(), root_hash.unwrap())?;
-    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: () , dep_hashes: None, root_hash: None}))
-}
+    let extra_data: CrateDependencies= extra_data_option.ok_or(EmptyCrateDependenciesError)?;
 
+    lib_util::finish_streaming(output, extra_data)?;
+    Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: ()}))
+}
 
 pub use self::analyze_streaming as analyze;
 pub use analyz::to_json::ExportStyle;

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -26,7 +26,7 @@ mod to_json;
 mod ty_json;
 use analyz::to_json::*;
 use analyz::ty_json::*;
-use lib_util::{self, JsonOutput, EntryKind, UniqueCrateId, CrateDependencies, EmptyCrateDependenciesError};
+use lib_util::{self, JsonOutput, EntryKind, UniqueCrateId, CrateDependencies};
 use schema_ver::SCHEMA_VER;
 
 use log::debug;
@@ -1440,12 +1440,12 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
     tcx: TyCtxt<'tcx>,
     export_style: ExportStyle,
     mk_output: F,
-) -> Result<(Option<AnalysisData<O>>, Option<CrateDependencies>), serde_cbor::Error> {
+) -> Result<Option<(AnalysisData<O>, CrateDependencies)>, serde_cbor::Error> {
     let mut extern_mir_paths = Vec::new();
 
     let outputs = tcx.output_filenames(());
     if !outputs.outputs.contains_key(&OutputType::Exe) {
-        return Ok((None, None));
+        return Ok(None);
     }
     let out_path = rustc_session::output::out_filename(
         tcx.sess,
@@ -1525,20 +1525,18 @@ fn analyze_inner<'tcx, O: JsonOutput, F: FnOnce(&Path) -> io::Result<O>>(
     // references them, but we check again here just in case.
     emit_new_defs(&mut ms, &mut out)?;
     let extra_data = CrateDependencies::new(root_hash, dep_hashes);
-    Ok((Some(AnalysisData { mir_path, extern_mir_paths, output: out}), Some(extra_data)))
+    Ok(Some((AnalysisData { mir_path, extern_mir_paths, output: out}, extra_data)))
 }
 
 pub fn analyze_nonstreaming<'tcx>(
     tcx: TyCtxt<'tcx>,
     export_style: ExportStyle,
 ) -> Result<Option<AnalysisData<()>>, serde_cbor::Error> {
-    let (opt_ad, extra_data_option) = analyze_inner(tcx, export_style, |_| { Ok(lib_util::Output::default()) })?;
-    let AnalysisData { mir_path, extern_mir_paths, output: out} = match opt_ad {
+    let opt_ad = analyze_inner(tcx, export_style, |_| { Ok(lib_util::Output::default()) })?;
+    let (AnalysisData { mir_path, extern_mir_paths, output: out}, extra_data) = match opt_ad {
         Some(x) => x,
         None => return Ok(None),
     };
-
-    let extra_data= extra_data_option.ok_or(EmptyCrateDependenciesError)?;
 
     let total_items = out.fns.len() + out.adts.len() + out.statics.len() + out.vtables.len() +
         out.traits.len() + out.intrinsics.len();
@@ -1566,12 +1564,11 @@ pub fn analyze_streaming<'tcx>(
     tcx: TyCtxt<'tcx>,
     export_style: ExportStyle,
 ) -> Result<Option<AnalysisData<()>>, serde_cbor::Error> {
-    let (opt_ad, extra_data_option)  = analyze_inner(tcx, export_style, lib_util::start_streaming)?;
-    let AnalysisData { mir_path, extern_mir_paths, output } = match opt_ad {
+    let opt_ad  = analyze_inner(tcx, export_style, lib_util::start_streaming)?;
+    let (AnalysisData { mir_path, extern_mir_paths, output }, extra_data) = match opt_ad {
         Some(x) => x,
         None => return Ok(None),
     };
-    let extra_data: CrateDependencies= extra_data_option.ok_or(EmptyCrateDependenciesError)?;
 
     lib_util::finish_streaming(output, extra_data)?;
     Ok(Some(AnalysisData { mir_path, extern_mir_paths, output: ()}))

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -33,6 +33,17 @@ use tar;
 use crate::schema_ver::SCHEMA_VER;
 use crate::tar_stream::{TarStream, TarEntryStream};
 
+#[derive(Debug, Default, Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct SvhHash{
+    pub name: String,
+    pub hash: String,
+}
+
+impl SvhHash{
+    pub fn new( name: String,hash: String) -> Self {
+        SvhHash { name, hash }
+    }
+}
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CrateIndex {
     /// Name table.  Contains every string in the crate that looks like it might be an item name.
@@ -49,9 +60,11 @@ pub struct CrateIndex {
 
     /// The schema version in use. (See also `SCHEMA_VER`.)
     pub version: u64,
-
+    /// The current crate's name and svh hash
+    pub root_hash: SvhHash,
     /// Mapping from the names of crates the current crate depends on to their Svh hashes as Strings.
-    pub svh_hashes: HashSet<(String, String)>
+    /// The [`SvhHash`] struct consist of a tuple of a crate name and its hash
+    pub dep_hashes: HashSet<SvhHash>
 }
 
 /// Metadata about a single item.
@@ -243,7 +256,7 @@ impl EmitterState {
         if is_test { self.tests.insert(name_id); }
     }
 
-    pub fn finish(self, svh_hashes: HashSet<(String, String)>) -> CrateIndex {
+    pub fn finish(self, dep_hashes: HashSet<SvhHash>, root_hash: SvhHash) -> CrateIndex {
         let names = self.intern.into_names();
 
         let mut items = HashMap::with_capacity(self.dep_map.len());
@@ -268,7 +281,7 @@ impl EmitterState {
 
         let version = SCHEMA_VER;
 
-        CrateIndex { names, items, roots, tests, version, svh_hashes }
+        CrateIndex { names, items, roots, tests, version, root_hash, dep_hashes }
     }
 }
 
@@ -358,12 +371,12 @@ impl<W: Write> Emitter<W> {
         Ok(())
     }
 
-    pub fn finish(self, svh_hashes: HashSet<(String, String)>) -> CrateIndex {
-        self.state.finish(svh_hashes)
+    pub fn finish(self, dep_hashes: HashSet<SvhHash>, root_hash: SvhHash) -> CrateIndex {
+        self.state.finish(dep_hashes, root_hash)
     }
 }
 
-pub fn write_indexed_crate<W>(out: W, j: &JsonValue, svh_hashes: HashSet<(String, String)>) -> serde_cbor::Result<()>
+pub fn write_indexed_crate<W>(out: W, j: &JsonValue, dep_hashes: HashSet<SvhHash>, root_hash: SvhHash) -> serde_cbor::Result<()>
 where W: Write + Send + 'static {
     // Serialize the two files to byte arrays.  This is needed so their lengths will be known when
     // creating the archive.
@@ -371,7 +384,7 @@ where W: Write + Send + 'static {
     let mut emitter = Emitter::new(&mut json_buf);
     emitter.emit_crate(j)?;
 
-    let index = emitter.finish(svh_hashes);
+    let index = emitter.finish(dep_hashes, root_hash);
     let index_buf = serde_cbor::to_vec(&index)?;
 
     let mut tar = tar::Builder::new(out);
@@ -559,10 +572,10 @@ impl<W: Write> StreamingEmitter<W> {
         Ok(se)
     }
 
-    pub fn finish(mut self, svh_hashes: HashSet<(String, String)>) -> io::Result<(W, CrateIndex)> {
+    pub fn finish(mut self, svh_hashes: HashSet<SvhHash>, root_hash: SvhHash) -> io::Result<(W, CrateIndex)> {
         // TODO: expose this through a method on Emitter rather than reaching into its internal
         // state.
-        let index = self.inner.state.finish(svh_hashes);
+        let index = self.inner.state.finish(svh_hashes, root_hash);
         write!(self.inner.writer, "]")?;
         Ok((self.inner.writer.w, index))
     }
@@ -621,8 +634,8 @@ pub fn start_streaming(path: &Path) -> io::Result<MirStream> {
     Ok(MirStream { emitter })
 }
 
-pub fn finish_streaming(ms: MirStream, svh_hashes: HashSet<(String, String)>) -> serde_cbor::Result<()> {
-    let (json_entry, index) = ms.emitter.finish(svh_hashes)?;
+pub fn finish_streaming(ms: MirStream, svh_hashes: HashSet<SvhHash>, root_hash: SvhHash) -> serde_cbor::Result<()> {
+    let (json_entry, index) = ms.emitter.finish(svh_hashes, root_hash)?;
     let tar = json_entry.finish_entry()?;
     let mut index_entry = tar.start_entry(make_tar_entry("index.cbor")?)?;
     serde_cbor::to_writer(&mut index_entry, &index)?;

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -669,12 +669,12 @@ impl std::fmt::Display for DependencyError {
 impl std::error::Error for DependencyError {}
 
 /// Function that checks if the crate dependencies were provided as inputs to the linker
-pub fn check_dependencies(crate_indices: &[CrateIndex]) -> Result<(), DependencyError>{
+pub fn check_dependencies(crate_indices: &[CrateIndex]) -> Result<(), DependencyError> {
     let mut linker_inputs: HashSet<SvhHash>  = HashSet::new();
-    for index in crate_indices{
+    for index in crate_indices {
         linker_inputs.insert(index.root_hash.clone());
     }
-    for index in crate_indices{
+    for index in crate_indices {
         let diff: Vec<SvhHash> = index.dep_hashes.difference(&linker_inputs).map(|hash|hash.clone()).collect();
         if diff.len() != 0 {
             return Err(DependencyError{root_hash: index.root_hash.clone(), dependency_hashes: diff});

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -705,6 +705,25 @@ impl std::fmt::Display for DependencyError {
 impl std::error::Error for DependencyError {}
 
 /// Function that checks if the crate dependencies were provided as inputs to the linker
+
+
+/*
+Note [Excluding proc macro crates]
+~~~~~~~~~~~~~~~~~~~~~
+(Courtesy of @spernsteiner)
+
+We exclude proc macro crates in the check below because they are not linked into the final artifact.
+In general, since proc macro crates are always compiled for the host architecture rather than the target 
+architecture (which may be different, even if in practice it's usually the same), 
+they can't be linked into target-architecture build outputs (and anyway there's no need, 
+since the proc macro code only runs at compile time).
+
+
+For example, suppose you have crate foo that depends on my_proc_macros and bar (a normal, non-proc-macro crate).  
+If you're on an amd64 machine and cross-compiling for wasm, then Cargo will build bar for wasm so it can be
+linked into the final wasm output, but it will build my_proc_macros for amd64 so the code from that crate 
+can be loaded and run while compiling foo (which happens on your amd64 build machine). 
+*/
 pub fn check_dependencies(crate_indices: &[CrateIndex]) -> Result<(), DependencyError> {
     let mut linker_inputs: HashSet<UniqueCrateId>  = HashSet::new();
     for index in crate_indices {

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -51,6 +51,36 @@ impl std::fmt::Display for UniqueCrateId {
     }
 }
 
+/*
+Note [Crate aliases]
+~~~~~~~~~~~~~~~~~~~~~
+
+Imagine for instance that you are doing something like this in your toml in say crux-mir's example-1:
+```
+[dependencies]
+
+generic-array-1 = {package = "generic-array", version = "1.4.4"}
+generic-array-2 = {package = "generic-array", version = "0.4"}
+```
+
+and then including them as
+
+```
+use generic_array_1::*;
+use generic_array_2::*;
+```
+
+Then these are translated into the following in the MIR file:
+
+{'dep_hashes': [
+        {'hash': 'b8ac3e84cb7ef863117d4a913e976710',
+               'name': 'generic_array'},
+        {'hash': '7b0428ba33d86c7150ce93427cfd1e59',
+         'name': 'generic_array'},
+]}
+
+i.e. the original crate name is conserved (rather than the crate alias), and each version has a different svh hash.
+*/
 impl UniqueCrateId{
     pub fn new( tcx: TyCtxt, cnum: CrateNum) -> Self {
         //  Note that crate aliases demarking different versions of the

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -779,20 +779,3 @@ impl From<DependencyError> for serde_cbor::Error {
         ser::Error::custom(error.to_string())
     }
 }
-
-#[derive(Debug)]
-pub struct EmptyCrateDependenciesError;
-
-impl std::fmt::Display for EmptyCrateDependenciesError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "The CrateDependencies struct that uniquely identifies a crate and its independencies was not provided!")
-    }
-}
-
-impl std::error::Error for EmptyCrateDependenciesError {}
-
-impl From<EmptyCrateDependenciesError> for serde_cbor::Error {
-    fn from(error: EmptyCrateDependenciesError) -> Self {
-        ser::Error::custom(error.to_string())
-    }
-}

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -25,6 +25,8 @@ use std::hash::Hash;
 use std::io::{self, Write, Cursor, BufWriter};
 use std::path::Path;
 
+
+use serde::ser;
 use serde_json::Value as JsonValue;
 use serde_cbor;
 use serde_json;
@@ -33,10 +35,17 @@ use tar;
 use crate::schema_ver::SCHEMA_VER;
 use crate::tar_stream::{TarStream, TarEntryStream};
 
-#[derive(Debug, Default, Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord, Hash, Clone)]
 pub struct SvhHash{
+    /// The name of crate
     pub name: String,
+    /// The Svh Hash of that crate as a string
     pub hash: String,
+}
+impl std::fmt::Display for SvhHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Crate< name: {}, Svh Hash: {} >", self.name, self.hash)
+    }
 }
 
 impl SvhHash{
@@ -60,7 +69,7 @@ pub struct CrateIndex {
 
     /// The schema version in use. (See also `SCHEMA_VER`.)
     pub version: u64,
-    /// The current crate's name and svh hash
+    /// The current crate's [`SvhHash`]
     pub root_hash: SvhHash,
     /// Mapping from the names of crates the current crate depends on to their Svh hashes as Strings.
     /// The [`SvhHash`] struct consist of a tuple of a crate name and its hash
@@ -643,4 +652,40 @@ pub fn finish_streaming(ms: MirStream, svh_hashes: HashSet<SvhHash>, root_hash: 
     let mut w = tar.finish()?;
     w.flush()?;
     Ok(())
+}
+
+#[derive(Debug)]
+pub struct DependencyError {
+    root_hash: SvhHash,
+    dependency_hashes: Vec<SvhHash>,
+}
+
+impl std::fmt::Display for DependencyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "The crate {} depends on {:#?} which was not provided as an input to the linker", self.root_hash, self.dependency_hashes)
+    }
+}
+
+impl std::error::Error for DependencyError {}
+
+/// Function that checks if the crate dependencies were provided as inputs to the linker
+pub fn check_dependencies(crate_indices: &[CrateIndex]) -> Result<(), DependencyError>{
+    let mut linker_inputs: HashSet<SvhHash>  = HashSet::new();
+    for index in crate_indices{
+        linker_inputs.insert(index.root_hash.clone());
+    }
+    for index in crate_indices{
+        let diff: Vec<SvhHash> = index.dep_hashes.difference(&linker_inputs).map(|hash|hash.clone()).collect();
+        if diff.len() != 0 {
+            return Err(DependencyError{root_hash: index.root_hash.clone(), dependency_hashes: diff});
+        }
+    }
+    return Ok(());
+}
+
+
+impl From<DependencyError> for serde_cbor::Error {
+    fn from(error: DependencyError) -> Self {
+        ser::Error::custom(error.to_string())
+    }
 }

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -21,6 +21,7 @@ use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
+use std::hash::Hash;
 use std::io::{self, Write, Cursor, BufWriter};
 use std::path::Path;
 
@@ -48,6 +49,9 @@ pub struct CrateIndex {
 
     /// The schema version in use. (See also `SCHEMA_VER`.)
     pub version: u64,
+
+    /// Mapping from the names of crates the current crate depends on to their Svh hashes as Strings.
+    pub svh_hashes: HashMap<String, String>
 }
 
 /// Metadata about a single item.
@@ -239,7 +243,7 @@ impl EmitterState {
         if is_test { self.tests.insert(name_id); }
     }
 
-    pub fn finish(self) -> CrateIndex {
+    pub fn finish(self, svh_hashes: HashMap<String, String>) -> CrateIndex {
         let names = self.intern.into_names();
 
         let mut items = HashMap::with_capacity(self.dep_map.len());
@@ -264,7 +268,7 @@ impl EmitterState {
 
         let version = SCHEMA_VER;
 
-        CrateIndex { names, items, roots, tests, version }
+        CrateIndex { names, items, roots, tests, version, svh_hashes }
     }
 }
 
@@ -354,12 +358,12 @@ impl<W: Write> Emitter<W> {
         Ok(())
     }
 
-    pub fn finish(self) -> CrateIndex {
-        self.state.finish()
+    pub fn finish(self, svh_hashes: HashMap<String, String>) -> CrateIndex {
+        self.state.finish(svh_hashes)
     }
 }
 
-pub fn write_indexed_crate<W>(out: W, j: &JsonValue) -> serde_cbor::Result<()>
+pub fn write_indexed_crate<W>(out: W, j: &JsonValue, svh_hashes: HashMap<String, String>) -> serde_cbor::Result<()>
 where W: Write + Send + 'static {
     // Serialize the two files to byte arrays.  This is needed so their lengths will be known when
     // creating the archive.
@@ -367,7 +371,7 @@ where W: Write + Send + 'static {
     let mut emitter = Emitter::new(&mut json_buf);
     emitter.emit_crate(j)?;
 
-    let index = emitter.finish();
+    let index = emitter.finish(svh_hashes);
     let index_buf = serde_cbor::to_vec(&index)?;
 
     let mut tar = tar::Builder::new(out);
@@ -555,10 +559,10 @@ impl<W: Write> StreamingEmitter<W> {
         Ok(se)
     }
 
-    pub fn finish(mut self) -> io::Result<(W, CrateIndex)> {
+    pub fn finish(mut self, svh_hashes: HashMap<String, String>) -> io::Result<(W, CrateIndex)> {
         // TODO: expose this through a method on Emitter rather than reaching into its internal
         // state.
-        let index = self.inner.state.finish();
+        let index = self.inner.state.finish(svh_hashes);
         write!(self.inner.writer, "]")?;
         Ok((self.inner.writer.w, index))
     }
@@ -617,8 +621,8 @@ pub fn start_streaming(path: &Path) -> io::Result<MirStream> {
     Ok(MirStream { emitter })
 }
 
-pub fn finish_streaming(ms: MirStream) -> serde_cbor::Result<()> {
-    let (json_entry, index) = ms.emitter.finish()?;
+pub fn finish_streaming(ms: MirStream, svh_hashes: HashMap<String, String>) -> serde_cbor::Result<()> {
+    let (json_entry, index) = ms.emitter.finish(svh_hashes)?;
     let tar = json_entry.finish_entry()?;
     let mut index_entry = tar.start_entry(make_tar_entry("index.cbor")?)?;
     serde_cbor::to_writer(&mut index_entry, &index)?;

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -24,7 +24,8 @@ use std::fs::File;
 use std::hash::Hash;
 use std::io::{self, Write, Cursor, BufWriter};
 use std::path::Path;
-
+use rustc_middle::ty::{ TyCtxt};
+use rustc_span::def_id::CrateNum;
 
 use serde::ser;
 use serde_json::Value as JsonValue;
@@ -36,23 +37,49 @@ use crate::schema_ver::SCHEMA_VER;
 use crate::tar_stream::{TarStream, TarEntryStream};
 
 #[derive(Debug, Default, Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord, Hash, Clone)]
-pub struct SvhHash{
-    /// The name of crate
+pub struct UniqueCrateId{
+    /// The name of the crate (regardless of crate aliases)
     pub name: String,
-    /// The Svh Hash of that crate as a string
+    /// A unique identifier for this crate that is based on the
+    /// Strict Version Hash (SVH). See how this struct is constructed
+    /// for more details.
     pub hash: String,
 }
-impl std::fmt::Display for SvhHash {
+impl std::fmt::Display for UniqueCrateId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Crate< name: {}, Svh Hash: {} >", self.name, self.hash)
     }
 }
 
-impl SvhHash{
-    pub fn new( name: String,hash: String) -> Self {
-        SvhHash { name, hash }
+impl UniqueCrateId{
+    pub fn new( tcx: TyCtxt, cnum: CrateNum) -> Self {
+        //  Note that crate aliases demarking different versions of the
+        //  same crate will have the same crate name but different crate
+        //  hashes.  
+        UniqueCrateId {    
+            name: tcx.crate_name(cnum).to_string(),
+            hash: tcx.crate_hash(cnum).to_string() 
+        }
     }
 }
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct CrateDependencies{
+    /// The crate's unique identifier 
+    root_hash:UniqueCrateId,
+    /// A hashset of unique identifiers for the crate's dependencies
+    dep_hashes: HashSet<UniqueCrateId>
+}
+
+impl CrateDependencies{
+    pub fn new( root_hash:UniqueCrateId, dep_hashes: HashSet<UniqueCrateId>) -> Self { 
+        CrateDependencies {             
+            root_hash,
+            dep_hashes
+        }
+    }
+}
+
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CrateIndex {
     /// Name table.  Contains every string in the crate that looks like it might be an item name.
@@ -69,12 +96,21 @@ pub struct CrateIndex {
 
     /// The schema version in use. (See also `SCHEMA_VER`.)
     pub version: u64,
-    /// The current crate's [`SvhHash`]
-    pub root_hash: SvhHash,
-    /// Mapping from the names of crates the current crate depends on to their Svh hashes as Strings.
-    /// The [`SvhHash`] struct consist of a tuple of a crate name and its hash
-    pub dep_hashes: HashSet<SvhHash>
+    /// Extra information that allows us to uniquely identify this crate and
+    /// it's dependencies
+    pub extra_data: CrateDependencies,
 }
+
+impl CrateIndex{
+    pub fn root_hash(&self) -> UniqueCrateId{
+        self.extra_data.root_hash.clone()
+    }
+    pub fn dep_hashes(&self) -> HashSet<UniqueCrateId>{
+        self.extra_data.dep_hashes.clone()
+    }
+}
+
+    
 
 /// Metadata about a single item.
 ///
@@ -265,7 +301,7 @@ impl EmitterState {
         if is_test { self.tests.insert(name_id); }
     }
 
-    pub fn finish(self, dep_hashes: HashSet<SvhHash>, root_hash: SvhHash) -> CrateIndex {
+    pub fn finish(self, extra_data: CrateDependencies) -> CrateIndex {
         let names = self.intern.into_names();
 
         let mut items = HashMap::with_capacity(self.dep_map.len());
@@ -290,7 +326,7 @@ impl EmitterState {
 
         let version = SCHEMA_VER;
 
-        CrateIndex { names, items, roots, tests, version, root_hash, dep_hashes }
+        CrateIndex { names, items, roots, tests, version, extra_data}
     }
 }
 
@@ -380,12 +416,12 @@ impl<W: Write> Emitter<W> {
         Ok(())
     }
 
-    pub fn finish(self, dep_hashes: HashSet<SvhHash>, root_hash: SvhHash) -> CrateIndex {
-        self.state.finish(dep_hashes, root_hash)
+    pub fn finish(self, extra_data: CrateDependencies) -> CrateIndex {
+        self.state.finish(extra_data)
     }
 }
 
-pub fn write_indexed_crate<W>(out: W, j: &JsonValue, dep_hashes: HashSet<SvhHash>, root_hash: SvhHash) -> serde_cbor::Result<()>
+pub fn write_indexed_crate<W>(out: W, j: &JsonValue, extra_data: CrateDependencies) -> serde_cbor::Result<()>
 where W: Write + Send + 'static {
     // Serialize the two files to byte arrays.  This is needed so their lengths will be known when
     // creating the archive.
@@ -393,7 +429,7 @@ where W: Write + Send + 'static {
     let mut emitter = Emitter::new(&mut json_buf);
     emitter.emit_crate(j)?;
 
-    let index = emitter.finish(dep_hashes, root_hash);
+    let index = emitter.finish(extra_data);
     let index_buf = serde_cbor::to_vec(&index)?;
 
     let mut tar = tar::Builder::new(out);
@@ -581,10 +617,10 @@ impl<W: Write> StreamingEmitter<W> {
         Ok(se)
     }
 
-    pub fn finish(mut self, svh_hashes: HashSet<SvhHash>, root_hash: SvhHash) -> io::Result<(W, CrateIndex)> {
+    pub fn finish(mut self, extra_data: CrateDependencies) -> io::Result<(W, CrateIndex)> {
         // TODO: expose this through a method on Emitter rather than reaching into its internal
         // state.
-        let index = self.inner.state.finish(svh_hashes, root_hash);
+        let index = self.inner.state.finish(extra_data);
         write!(self.inner.writer, "]")?;
         Ok((self.inner.writer.w, index))
     }
@@ -643,8 +679,8 @@ pub fn start_streaming(path: &Path) -> io::Result<MirStream> {
     Ok(MirStream { emitter })
 }
 
-pub fn finish_streaming(ms: MirStream, svh_hashes: HashSet<SvhHash>, root_hash: SvhHash) -> serde_cbor::Result<()> {
-    let (json_entry, index) = ms.emitter.finish(svh_hashes, root_hash)?;
+pub fn finish_streaming(ms: MirStream, extra_data: CrateDependencies) -> serde_cbor::Result<()> {
+    let (json_entry, index) = ms.emitter.finish(extra_data)?;
     let tar = json_entry.finish_entry()?;
     let mut index_entry = tar.start_entry(make_tar_entry("index.cbor")?)?;
     serde_cbor::to_writer(&mut index_entry, &index)?;
@@ -656,8 +692,8 @@ pub fn finish_streaming(ms: MirStream, svh_hashes: HashSet<SvhHash>, root_hash: 
 
 #[derive(Debug)]
 pub struct DependencyError {
-    root_hash: SvhHash,
-    dependency_hashes: Vec<SvhHash>,
+    root_hash: UniqueCrateId,
+    dependency_hashes: Vec<UniqueCrateId>,
 }
 
 impl std::fmt::Display for DependencyError {
@@ -670,14 +706,14 @@ impl std::error::Error for DependencyError {}
 
 /// Function that checks if the crate dependencies were provided as inputs to the linker
 pub fn check_dependencies(crate_indices: &[CrateIndex]) -> Result<(), DependencyError> {
-    let mut linker_inputs: HashSet<SvhHash>  = HashSet::new();
+    let mut linker_inputs: HashSet<UniqueCrateId>  = HashSet::new();
     for index in crate_indices {
-        linker_inputs.insert(index.root_hash.clone());
+        linker_inputs.insert(index.root_hash());
     }
     for index in crate_indices {
-        let diff: Vec<SvhHash> = index.dep_hashes.difference(&linker_inputs).map(|hash|hash.clone()).collect();
+        let diff: Vec<UniqueCrateId> = index.dep_hashes().difference(&linker_inputs).map(|hash|hash.clone()).collect();
         if diff.len() != 0 {
-            return Err(DependencyError{root_hash: index.root_hash.clone(), dependency_hashes: diff});
+            return Err(DependencyError{root_hash: index.root_hash(), dependency_hashes: diff});
         }
     }
     return Ok(());
@@ -686,6 +722,23 @@ pub fn check_dependencies(crate_indices: &[CrateIndex]) -> Result<(), Dependency
 
 impl From<DependencyError> for serde_cbor::Error {
     fn from(error: DependencyError) -> Self {
+        ser::Error::custom(error.to_string())
+    }
+}
+
+#[derive(Debug)]
+pub struct EmptyCrateDependenciesError;
+
+impl std::fmt::Display for EmptyCrateDependenciesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "The CrateDependencies struct that uniquely identifies a crate and its independencies was not provided!")
+    }
+}
+
+impl std::error::Error for EmptyCrateDependenciesError {}
+
+impl From<EmptyCrateDependenciesError> for serde_cbor::Error {
+    fn from(error: EmptyCrateDependenciesError) -> Self {
         ser::Error::custom(error.to_string())
     }
 }

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -51,7 +51,7 @@ pub struct CrateIndex {
     pub version: u64,
 
     /// Mapping from the names of crates the current crate depends on to their Svh hashes as Strings.
-    pub svh_hashes: HashMap<String, String>
+    pub svh_hashes: HashSet<(String, String)>
 }
 
 /// Metadata about a single item.
@@ -243,7 +243,7 @@ impl EmitterState {
         if is_test { self.tests.insert(name_id); }
     }
 
-    pub fn finish(self, svh_hashes: HashMap<String, String>) -> CrateIndex {
+    pub fn finish(self, svh_hashes: HashSet<(String, String)>) -> CrateIndex {
         let names = self.intern.into_names();
 
         let mut items = HashMap::with_capacity(self.dep_map.len());
@@ -358,12 +358,12 @@ impl<W: Write> Emitter<W> {
         Ok(())
     }
 
-    pub fn finish(self, svh_hashes: HashMap<String, String>) -> CrateIndex {
+    pub fn finish(self, svh_hashes: HashSet<(String, String)>) -> CrateIndex {
         self.state.finish(svh_hashes)
     }
 }
 
-pub fn write_indexed_crate<W>(out: W, j: &JsonValue, svh_hashes: HashMap<String, String>) -> serde_cbor::Result<()>
+pub fn write_indexed_crate<W>(out: W, j: &JsonValue, svh_hashes: HashSet<(String, String)>) -> serde_cbor::Result<()>
 where W: Write + Send + 'static {
     // Serialize the two files to byte arrays.  This is needed so their lengths will be known when
     // creating the archive.
@@ -559,7 +559,7 @@ impl<W: Write> StreamingEmitter<W> {
         Ok(se)
     }
 
-    pub fn finish(mut self, svh_hashes: HashMap<String, String>) -> io::Result<(W, CrateIndex)> {
+    pub fn finish(mut self, svh_hashes: HashSet<(String, String)>) -> io::Result<(W, CrateIndex)> {
         // TODO: expose this through a method on Emitter rather than reaching into its internal
         // state.
         let index = self.inner.state.finish(svh_hashes);
@@ -621,7 +621,7 @@ pub fn start_streaming(path: &Path) -> io::Result<MirStream> {
     Ok(MirStream { emitter })
 }
 
-pub fn finish_streaming(ms: MirStream, svh_hashes: HashMap<String, String>) -> serde_cbor::Result<()> {
+pub fn finish_streaming(ms: MirStream, svh_hashes: HashSet<(String, String)>) -> serde_cbor::Result<()> {
     let (json_entry, index) = ms.emitter.finish(svh_hashes)?;
     let tar = json_entry.finish_entry()?;
     let mut index_entry = tar.start_entry(make_tar_entry("index.cbor")?)?;

--- a/src/lib_util.rs
+++ b/src/lib_util.rs
@@ -66,6 +66,11 @@ impl UniqueCrateId{
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct CrateDependencies{
     /// The crate's unique identifier 
+    /// 
+    /// Note that when we perform the validation check to see if all
+    /// listed crate dependencies have been passed to the linker, the
+    /// root_hash below allows us to track which crates were passed as inputs to the 
+    /// linker.
     root_hash:UniqueCrateId,
     /// A hashset of unique identifiers for the crate's dependencies
     dep_hashes: HashSet<UniqueCrateId>

--- a/src/link.rs
+++ b/src/link.rs
@@ -4,8 +4,9 @@ use std::io::{self, Write};
 use serde_cbor;
 use serde_json;
 
-use crate::lib_util::{self, CrateIndex, InternTable, EntryKind, StringId};
+use crate::lib_util::{self, CrateIndex, EntryKind, InternTable, StringId, check_dependencies};
 use crate::schema_ver::SCHEMA_VER;
+
 
 
 fn read_crates(
@@ -96,6 +97,8 @@ where W: Write {
     let (roots, tests) = collect_roots(&indexes, &translate);
     check_matching_versions(&indexes)?;
 
+    // Check if the crate dependencies were provided as inputs to the linker
+    check_dependencies(&indexes)?;
 
     let mut seen_names = HashSet::new();
     let mut worklist = roots.clone();


### PR DESCRIPTION
This MR store the crate and its dependencies SVH hashes in MIR files in order to keep track of what crates have been updated later down the line. We will specifically be using this to improve the compile time of some CI builds in `crux-mir` that don't need to be recompiled if neither the `mir-json` nor the crates used have changed.