### PR TITLE
Simplify away some unused code related to constant evaluation

### DIFF
--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -947,10 +947,6 @@ fn emit_static(ms: &mut MirState, out: &mut impl JsonOutput, def_id: DefId) -> i
     emit_fn(ms, out, &name, None, mir)?;
     emit_static_decl(ms, out, &name, mir.return_ty(), tcx.is_mutable_static(def_id))?;
 
-    for (idx, mir) in tcx.promoted_mir(def_id).iter_enumerated() {
-        emit_promoted(ms, out, &name, idx, mir)?;
-    }
-
     Ok(())
 }
 
@@ -1144,31 +1140,6 @@ fn emit_instance<'tcx>(
     let mir = tcx.arena.alloc(mir);
     emit_fn(ms, out, &name, Some(ty_inst), mir)?;
 
-    if let ty::InstanceKind::Item(def_id) = ty_inst.def {
-        for (idx, mir) in tcx.promoted_mir(def_id).iter_enumerated() {
-            let mir = ty_inst.instantiate_mir_and_normalize_erasing_regions(
-                tcx,
-                ty::TypingEnv::fully_monomorphized(),
-                ty::EarlyBinder::bind(mir.clone()),
-            );
-            let mir = tcx.arena.alloc(mir);
-            emit_promoted(ms, out, &name, idx, mir)?;
-        }
-    }
-
-    Ok(())
-}
-
-fn emit_promoted<'tcx>(
-    ms: &mut MirState<'_, 'tcx>,
-    out: &mut impl JsonOutput,
-    parent: &str,
-    idx: mir::Promoted,
-    mir: &'tcx Body<'tcx>,
-) -> io::Result<()> {
-    let name = format!("{}::{{{{promoted}}}}[{}]", parent, idx.as_usize());
-    emit_fn(ms, out, &name, None, mir)?;
-    emit_static_decl(ms, out, &name, mir.return_ty(), false)?;
     Ok(())
 }
 

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -945,23 +945,11 @@ fn emit_static(ms: &mut MirState, out: &mut impl JsonOutput, def_id: DefId) -> i
     // let mir = tcx.optimized_mir(def_id);
     let mir = tcx.mir_for_ctfe(def_id);
     emit_fn(ms, out, &name, None, mir)?;
-    emit_static_decl(ms, out, &name, mir.return_ty(), tcx.is_mutable_static(def_id))?;
-
-    Ok(())
-}
-
-/// Add a new static declaration to `out.statics`.
-fn emit_static_decl<'tcx>(
-    ms: &mut MirState<'_, 'tcx>,
-    out: &mut impl JsonOutput,
-    name: &str,
-    ty: ty::Ty<'tcx>,
-    mutable: bool,
-) -> io::Result<()> {
+    // Add a new static declaration to `out.statics`.
     let j = json!({
         "name": name,
-        "ty": ty.to_json(ms),
-        "mutable": mutable,
+        "ty": mir.return_ty().to_json(ms),
+        "mutable": tcx.is_mutable_static(def_id),
         "kind": "body",
     });
     out.emit(EntryKind::Static, j)?;

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -1379,11 +1379,11 @@ pub fn try_render_opty<'tcx>(
         ty::TyKind::Slice(_) => unreachable!("slice type should not occur here"),
 
         // similar to ref in some ways
-        ty::TyKind::RawPtr(pty, mutability) =>
-            try_render_ref_opty(mir, icx, op_ty, pty, mutability)?,
+        ty::TyKind::RawPtr(_, mutability) =>
+            try_render_ref_opty(mir, icx, op_ty, mutability)?,
 
-        ty::TyKind::Ref(_, rty, mutability) =>
-            try_render_ref_opty(mir, icx, op_ty, rty, mutability)?,
+        ty::TyKind::Ref(_, _, mutability) =>
+            try_render_ref_opty(mir, icx, op_ty, mutability)?,
 
         ty::TyKind::FnDef(_, _) |
         ty::TyKind::Never => json!({"kind": "zst"}),
@@ -1490,7 +1490,6 @@ fn try_render_opty_upvars<'tcx>(
 fn make_allocation_body<'tcx>(
     mir: &mut MirState<'_, 'tcx>,
     icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
-    rty: ty::Ty<'tcx>,
     d: &MPlaceTy<'tcx>,
     is_mut: bool,
 ) -> serde_json::Value {
@@ -1499,9 +1498,9 @@ fn make_allocation_body<'tcx>(
     fn do_default<'tcx>(
         mir: &mut MirState<'_, 'tcx>,
         icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
-        rty: ty::Ty<'tcx>,
         d: &MPlaceTy<'tcx>,
     ) -> serde_json::Value {
+        let rty = d.layout.ty;
         let rlayout = mir.tcx.layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(rty)).unwrap();
         let mpty: MPlaceTy = d.offset_with_meta(Size::ZERO, OffsetMode::Inbounds, d.meta(), rlayout, icx).unwrap();
         let rendered = try_render_opty(mir, icx, &mpty.into());
@@ -1543,7 +1542,7 @@ fn make_allocation_body<'tcx>(
             })
         }
 
-        match *rty.kind() {
+        match *d.layout.ty.kind() {
             // Special cases for references to unsized types. Currently, the
             // following are supported:
             //
@@ -1588,21 +1587,20 @@ fn make_allocation_body<'tcx>(
             },
             ty::TyKind::Dynamic(ref preds, _) => {
                 let unpacked_d = unpack_dyn_place(icx, d, preds).unwrap();
-                return do_default(mir, icx, unpacked_d.layout.ty, &unpacked_d);
+                return do_default(mir, icx, &unpacked_d);
             },
             _ => ()
         }
     }
 
     // Default case
-    return do_default(mir, icx, rty, d);
+    return do_default(mir, icx, d);
 }
 
 fn try_render_ref_opty<'tcx>(
     mir: &mut MirState<'_, 'tcx>,
     icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
     op_ty: &interpret::OpTy<'tcx>,
-    rty: ty::Ty<'tcx>,
     mutability: hir::Mutability,
 ) -> Option<serde_json::Value> {
     let tcx = mir.tcx;
@@ -1638,7 +1636,7 @@ fn try_render_ref_opty<'tcx>(
                 Some(alloc_id) => alloc_id.to_owned(),
                 None => {
                     // create the allocation
-                    let body = make_allocation_body(mir, icx, rty, &d, is_mut);
+                    let body = make_allocation_body(mir, icx, &d, is_mut);
                     mir.allocs.insert(tcx, ca, ty, body)
                 }
             };
@@ -1680,7 +1678,7 @@ fn try_render_ref_opty<'tcx>(
         // * Trait objects (&dyn Trait)
         //
         // These special cases and the ones in make_allocation_body above should be kept in sync.
-        match *rty.kind() {
+        match *d.layout.ty.kind() {
             ty::TyKind::Str | ty::TyKind::Slice(_) =>
                 return Some(do_slice(icx, &d, def_id_json)),
             ty::TyKind::Adt(adt_def, _) if tcx.is_lang_item(adt_def.did(), LangItem::CStr) =>


### PR DESCRIPTION
This PR contains a series of commits that removes some unused or redundant code in the constant evaluation machinery:

* `make_allocation_body` and `try_render_ref_opty` take `Ty` arguments, but these are redundant because these types are always equal to the ones contained in he coresponding `MPlaceTy` arguments. These `Ty` arguments are now removed.
* Remove the `emit_promoted` function. Nowadays, promoteds are only temporarily created during constant evaluation, and they never survive all the way through to the final, evaluated result. As such, there is no point in generating functions or static items for promoted things, as they will simply be eliminated later by `mir-json`'s dead code elimination.
* After `emit_promoted`'s removal, the `emit_static_decl` function now only has a single call site in `emit_static`, and the
implementation of `emit_static_decl` is not that complex. As such, we now inline `emit_static_decl` into `emit_static` to simplify things.

Progress towards #177.