### PR TITLE
Evaluate static initializers at compile time

### DIFF
--- a/SCHEMA_CHANGELOG.md
+++ b/SCHEMA_CHANGELOG.md
@@ -8,6 +8,8 @@ versioned separately.)
   * Static: the `kind: "body"` variant has been **removed**. All statics now
     carry a pre-evaluated `rendered` value. Both ordinary and thread-local
     statics use `kind: "constant"`.
+  * Changes the `union` kind of `ConstVal` to have a variant and value
+    associated with it.
 
 ## 12
 

--- a/SCHEMA_CHANGELOG.md
+++ b/SCHEMA_CHANGELOG.md
@@ -3,6 +3,12 @@ The following document describes the changes to the JSON schema that
 as a changelog for the code in the `mir-json` tools themselves, which are
 versioned separately.)
 
+## 13
+
+  * Static: the `kind: "body"` variant has been **removed**. All statics now
+    carry a pre-evaluated `rendered` value. Both ordinary and thread-local
+    statics use `kind: "constant"`.
+
 ## 12
 
   * Instance: `ClosureShim` has been renamed to `CloneShim`.

--- a/doc/mir-json-schema.ts
+++ b/doc/mir-json-schema.ts
@@ -5,7 +5,7 @@
 
 /// The MIR JSON format
 type MIR = {
-  version: 12,
+  version: 13,
   fns: Fn[],
   adts: Adt[],
   statics: Static[],
@@ -192,9 +192,11 @@ type Layout = {
 // -----------------------------------------------------------------------------
 
 /// Globals
+///
+/// Both ordinary and thread-local statics are represented uniformly with
+/// `kind: "constant"`.
 type Static =
     { kind: "constant", name: DefId, ty: Ty, mutable: boolean, rendered: ConstVal }
-  | { kind: "body",     name: DefId, ty: Ty, mutable: boolean }
 
 
 // -----------------------------------------------------------------------------

--- a/doc/mir-json-schema.ts
+++ b/doc/mir-json-schema.ts
@@ -282,7 +282,7 @@ type ConstVal =
   | { kind: "strbody", len: number, elements: number[] }
   | { kind: "struct",  fields: ConstVal[] }
   | { kind: "enum", variant: number, fields: ConstVal[] }
-  | { kind: "union" }
+  | { kind: "union", variant: number, val: ConstVal }
   | { kind: "fndef", def_id: DefId }
   | { kind: "static_ref", def_id: DefId }
   | { kind: "zst" }

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -947,10 +947,6 @@ fn emit_static(ms: &mut MirState, out: &mut impl JsonOutput, def_id: DefId) -> i
     emit_fn(ms, out, &name, None, mir)?;
     emit_static_decl(ms, out, &name, mir.return_ty(), tcx.is_mutable_static(def_id))?;
 
-    for (idx, mir) in tcx.promoted_mir(def_id).iter_enumerated() {
-        emit_promoted(ms, out, &name, idx, mir)?;
-    }
-
     Ok(())
 }
 
@@ -1144,31 +1140,6 @@ fn emit_instance<'tcx>(
     let mir = tcx.arena.alloc(mir);
     emit_fn(ms, out, &name, Some(ty_inst), mir)?;
 
-    if let ty::InstanceKind::Item(def_id) = ty_inst.def {
-        for (idx, mir) in tcx.promoted_mir(def_id).iter_enumerated() {
-            let mir = ty_inst.instantiate_mir_and_normalize_erasing_regions(
-                tcx,
-                ty::TypingEnv::fully_monomorphized(),
-                ty::EarlyBinder::bind(mir.clone()),
-            );
-            let mir = tcx.arena.alloc(mir);
-            emit_promoted(ms, out, &name, idx, mir)?;
-        }
-    }
-
-    Ok(())
-}
-
-fn emit_promoted<'tcx>(
-    ms: &mut MirState<'_, 'tcx>,
-    out: &mut impl JsonOutput,
-    parent: &str,
-    idx: mir::Promoted,
-    mir: &'tcx Body<'tcx>,
-) -> io::Result<()> {
-    let name = format!("{}::{{{{promoted}}}}[{}]", parent, idx.as_usize());
-    emit_fn(ms, out, &name, None, mir)?;
-    emit_static_decl(ms, out, &name, mir.return_ty(), false)?;
     Ok(())
 }
 

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -876,7 +876,7 @@ fn emit_trait<'tcx>(
 }
 
 
-/// Emit all statics defined in the current crate.
+/// Emit all statics defined in the current crate. Extern statics are not exported.
 fn emit_statics(ms: &mut MirState, out: &mut impl JsonOutput) -> io::Result<()> {
     let parts = ms.tcx.collect_and_partition_mono_items(());
     for cgu in parts.codegen_units {
@@ -909,49 +909,34 @@ const X: &[u64] = &[42];
 static Y: &[&[u64]] = &[&X];
 
 When compiling this code, a nested static is created for the `&X` portion of
-`Y`'s body.
-
-Nested statics are treated very specially in the compiler, and they are not
-given types like other static items have. This doesn't cause issues for the
-flat "bytes and pointers" memory representation that rustc uses for the
-contents of allocations, but it is incompatible with the current crucible-mir
-memory model. The crucible-mir memory model requires a structured, typed
-representation of values, which we can extract from a flat allocation only if
-we know the correct type to extract into. Because nested statics don't
-explicitly store their types anywhere, our only hope of supporting them would
-be to stumble upon a reference to the same allocation in some other context
-where we do know the expected type.
-
-Thankfully, we can get away without needing to emit any entries for nested
-static items. This is because nested statics don't actually exist in the body
-of a static item itself. Rather, they are created as a side effect of
-evaluating the body down to a ConstAllocation, and the final ConstAllocation
-may reference those nested statics. (See
+`Y`'s body. See
 https://github.com/GaloisInc/mir-json/issues/129#issuecomment-3387602092 for a
-more thorough exploration of how nested static items arise during compilation.)
-mir-json, on the other hand, emits the MIR *body*, and to the best of our
-understanding, the MIR body exists prior to the creation of any nested statics.
-As a result, the emitted JSON for the MIR body won't reference nested statics
-at all.
+more thorough exploration of how nested static items arise during compilation.
 
-Implementation-wise, this means that we simply skip over any `MonoItem` that
-corresponds to a `Static` item with `nested: true`.
+Nested statics are treated specially in the compiler, and they are not given
+types like ordinary static items have. This is a problem for our renderer,
+which needs a structured, typed representation of each value. Instead of
+emitting nested statics as top-level entries in the `statics` table, we
+render them inline at the reference site: when `try_render_ref_opty` finds
+that a pointer points at a nested-static allocation, it evaluates that
+static's initializer and interns it under an anonymous `{{alloc}}` name,
+using the surrounding pointer's pointee type to drive the render.
+
+As a result, we skip any `MonoItem` here that corresponds to a `Static` with
+`nested: true` — those items are reached (and emitted) through their
+referring static rather than in their own right.
 */
 
+/// Emit a single static as a `kind: "constant"` entry in the `statics`
+/// table, evaluating and rendering its initializer via
+/// [`render_static_body`].
 fn emit_static(ms: &mut MirState, out: &mut impl JsonOutput, def_id: DefId) -> io::Result<()> {
     let tcx = ms.tcx;
     let name = def_id_str(tcx, def_id);
+    let ty = tcx.type_of(def_id).instantiate_identity();
+    let is_mut = tcx.is_mutable_static(def_id);
 
-    // let mir = tcx.optimized_mir(def_id);
-    let mir = tcx.mir_for_ctfe(def_id);
-    emit_fn(ms, out, &name, None, mir)?;
-    // Add a new static declaration to `out.statics`.
-    let j = json!({
-        "name": name,
-        "ty": mir.return_ty().to_json(ms),
-        "mutable": tcx.is_mutable_static(def_id),
-        "kind": "body",
-    });
+    let j = render_static_body(ms, def_id, ty, name, is_mut);
     out.emit(EntryKind::Static, j)?;
     emit_new_defs(ms, out)
 }

--- a/src/analyz/mod.rs
+++ b/src/analyz/mod.rs
@@ -945,23 +945,11 @@ fn emit_static(ms: &mut MirState, out: &mut impl JsonOutput, def_id: DefId) -> i
     // let mir = tcx.optimized_mir(def_id);
     let mir = tcx.mir_for_ctfe(def_id);
     emit_fn(ms, out, &name, None, mir)?;
-    emit_static_decl(ms, out, &name, mir.return_ty(), tcx.is_mutable_static(def_id))?;
-
-    Ok(())
-}
-
-/// Add a new static declaration to `out.statics`.
-fn emit_static_decl<'tcx>(
-    ms: &mut MirState<'_, 'tcx>,
-    out: &mut impl JsonOutput,
-    name: &str,
-    ty: ty::Ty<'tcx>,
-    mutable: bool,
-) -> io::Result<()> {
+    // Add a new static declaration to `out.statics`.
     let j = json!({
         "name": name,
-        "ty": ty.to_json(ms),
-        "mutable": mutable,
+        "ty": mir.return_ty().to_json(ms),
+        "mutable": tcx.is_mutable_static(def_id),
         "kind": "body",
     });
     out.emit(EntryKind::Static, j)?;

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -2,6 +2,7 @@ use rustc_abi::FieldsShape;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_hashes::Hash64;
 use rustc_hir as hir;
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::DefId;
 use rustc_hir::lang_items::LangItem;
 use rustc_index::{IndexVec, Idx};
@@ -1487,6 +1488,10 @@ fn try_render_opty_upvars<'tcx>(
     Some(upvar_vals)
 }
 
+/// Produce a `"kind": "constant"` JSON entry with all fields except `name`
+/// filled in. Callers are responsible for setting `name`: `intern_alloc`
+/// lets `AllocIntern::insert` mint an anonymous `{{alloc}}` id, while
+/// `render_static_body` supplies the static's real name.
 fn make_allocation_body<'tcx>(
     mir: &mut MirState<'_, 'tcx>,
     icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
@@ -1499,15 +1504,16 @@ fn make_allocation_body<'tcx>(
         mir: &mut MirState<'_, 'tcx>,
         icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
         d: &MPlaceTy<'tcx>,
+        is_mut: bool,
     ) -> serde_json::Value {
         let rty = d.layout.ty;
         let rlayout = mir.tcx.layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(rty)).unwrap();
         let mpty: MPlaceTy = d.offset_with_meta(Size::ZERO, OffsetMode::Inbounds, d.meta(), rlayout, icx).unwrap();
-        let rendered = try_render_opty(mir, icx, &mpty.into());
+        let rendered = render_opty(mir, icx, &mpty.into());
 
         json!({
             "kind": "constant",
-            "mutable": false,
+            "mutable": is_mut,
             "ty": rty.to_json(mir),
             "rendered": rendered,
         })
@@ -1587,14 +1593,35 @@ fn make_allocation_body<'tcx>(
             },
             ty::TyKind::Dynamic(ref preds, _) => {
                 let unpacked_d = unpack_dyn_place(icx, d, preds).unwrap();
-                return do_default(mir, icx, &unpacked_d);
+                return do_default(mir, icx, &unpacked_d, false);
             },
             _ => ()
         }
     }
 
     // Default case
-    return do_default(mir, icx, d);
+    return do_default(mir, icx, d, is_mut);
+}
+
+/// Look up an anonymous allocation in the intern table, rendering and
+/// inserting it on first sight. Returns the JSON reference (its interned
+/// `{{alloc}}` name) that downstream should use to point at it.
+fn intern_alloc<'tcx>(
+    mir: &mut MirState<'_, 'tcx>,
+    icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
+    ca: interpret::ConstAllocation<'tcx>,
+    ty: ty::Ty<'tcx>,
+    d: &MPlaceTy<'tcx>,
+    is_mut: bool,
+) -> serde_json::Value {
+    let def_id_str = match mir.allocs.get(ca, ty) {
+        Some(alloc_id) => alloc_id.to_owned(),
+        None => {
+            let body = make_allocation_body(mir, icx, d, is_mut);
+            mir.allocs.insert(mir.tcx, ca, ty, body)
+        }
+    };
+    def_id_str.to_json(mir)
 }
 
 fn try_render_ref_opty<'tcx>(
@@ -1628,20 +1655,33 @@ fn try_render_ref_opty<'tcx>(
     let alloc = tcx.try_get_global_alloc(prov?.alloc_id())?;
 
     let def_id_json = match alloc {
-        interpret::GlobalAlloc::Static(def_id) =>
-            def_id.to_json(mir),
-        interpret::GlobalAlloc::Memory(ca) => {
-            let ty = op_ty.layout.ty;
-            let def_id_str = match mir.allocs.get(ca, ty) {
-                Some(alloc_id) => alloc_id.to_owned(),
-                None => {
-                    // create the allocation
-                    let body = make_allocation_body(mir, icx, &d, is_mut);
-                    mir.allocs.insert(tcx, ca, ty, body)
-                }
-            };
-            def_id_str.to_json(mir)
+        interpret::GlobalAlloc::Static(def_id) => {
+            if matches!(tcx.def_kind(def_id), DefKind::Static { nested: true, .. }) {
+                // Nested statics have no name of their own that downstream can
+                // refer to, so we handle them the same way as `GlobalAlloc::Memory`:
+                // render the initializer here and intern it under an anonymous name,
+                // using the surrounding pointer's pointee type.
+
+                // Rustc does not emit thread-local nested statics.
+                debug_assert!(
+                    !tcx.is_thread_local_static(def_id),
+                    "nested static {:?} is thread-local — rustc invariant violated",
+                    def_id,
+                );
+
+                let ca = tcx.eval_static_initializer(def_id).unwrap_or_else(|e|
+                    panic!(
+                        "eval_static_initializer failed for nested static {:?}: {:?}",
+                        def_id, e,
+                    )
+                );
+                intern_alloc(mir, icx, ca, op_ty.layout.ty, &d, is_mut)
+            } else {
+                def_id.to_json(mir)
+            }
         }
+        interpret::GlobalAlloc::Memory(ca) =>
+            intern_alloc(mir, icx, ca, op_ty.layout.ty, &d, is_mut),
         interpret::GlobalAlloc::TypeId {..} => {
             return raw_ptr(offset);
         }
@@ -1715,6 +1755,49 @@ fn try_render_ref_opty<'tcx>(
         "kind": "static_ref",
         "def_id": def_id_json,
     }));
+}
+
+/// Evaluate a static's initializer and render it as a complete
+/// `kind: "constant"` JSON entry ready to be emitted.
+pub fn render_static_body<'tcx>(
+    mir: &mut MirState<'_, 'tcx>,
+    def_id: DefId,
+    ty: ty::Ty<'tcx>,
+    name: String,
+    is_mut: bool,
+) -> serde_json::Value {
+    use rustc_const_eval::interpret::{CtfeProvenance, Pointer};
+
+    let tcx = mir.tcx;
+    let ca = tcx.eval_static_initializer(def_id).unwrap_or_else(|e|
+        panic!(
+            "eval_static_initializer failed for {:?} ({:?}): {:?}",
+            def_id, tcx.def_kind(def_id), e,
+        )
+    );
+
+    let mut icx = interpret::InterpCx::new(
+        tcx,
+        tcx.def_span(def_id),
+        ty::TypingEnv::fully_monomorphized(),
+        RenderConstMachine::new(),
+    );
+
+    let layout = tcx.layout_of(
+        ty::TypingEnv::fully_monomorphized().as_query_input(ty),
+    ).unwrap();
+
+    // Mint a fresh AllocId for this ConstAllocation. This is distinct from
+    // whatever AllocId rustc uses for this static internally, but this is okay
+    // because we only use the interned ConstAllocation and not the AllocId
+    // to identify the allocation (such as in AllocIntern keys).
+    let alloc_id = tcx.reserve_and_set_memory_alloc(ca);
+    let ptr = Pointer::new(CtfeProvenance::from(alloc_id), Size::ZERO);
+    let mpty = icx.ptr_to_mplace(ptr.into(), layout);
+
+    let mut j = make_allocation_body(mir, &mut icx, &mpty, is_mut);
+    j["name"] = name.into();
+    j
 }
 
 pub fn as_opty<'tcx>(

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -1379,11 +1379,11 @@ pub fn try_render_opty<'tcx>(
         ty::TyKind::Slice(_) => unreachable!("slice type should not occur here"),
 
         // similar to ref in some ways
-        ty::TyKind::RawPtr(pty, mutability) =>
-            try_render_ref_opty(mir, icx, op_ty, pty, mutability)?,
+        ty::TyKind::RawPtr(_, mutability) =>
+            try_render_ref_opty(mir, icx, op_ty, mutability)?,
 
-        ty::TyKind::Ref(_, rty, mutability) =>
-            try_render_ref_opty(mir, icx, op_ty, rty, mutability)?,
+        ty::TyKind::Ref(_, _, mutability) =>
+            try_render_ref_opty(mir, icx, op_ty, mutability)?,
 
         ty::TyKind::FnDef(_, _) |
         ty::TyKind::Never => json!({"kind": "zst"}),
@@ -1490,7 +1490,6 @@ fn try_render_opty_upvars<'tcx>(
 fn make_allocation_body<'tcx>(
     mir: &mut MirState<'_, 'tcx>,
     icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
-    rty: ty::Ty<'tcx>,
     d: &MPlaceTy<'tcx>,
     is_mut: bool,
 ) -> serde_json::Value {
@@ -1499,9 +1498,9 @@ fn make_allocation_body<'tcx>(
     fn do_default<'tcx>(
         mir: &mut MirState<'_, 'tcx>,
         icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
-        rty: ty::Ty<'tcx>,
         d: &MPlaceTy<'tcx>,
     ) -> serde_json::Value {
+        let rty = d.layout.ty;
         let rlayout = mir.tcx.layout_of(ty::TypingEnv::fully_monomorphized().as_query_input(rty)).unwrap();
         let mpty: MPlaceTy = d.offset_with_meta(Size::ZERO, OffsetMode::Inbounds, d.meta(), rlayout, icx).unwrap();
         let rendered = try_render_opty(mir, icx, &mpty.into());
@@ -1543,7 +1542,7 @@ fn make_allocation_body<'tcx>(
             })
         }
 
-        match *rty.kind() {
+        match *d.layout.ty.kind() {
             // Special cases for references to unsized types. Currently, the
             // following are supported:
             //
@@ -1588,21 +1587,20 @@ fn make_allocation_body<'tcx>(
             },
             ty::TyKind::Dynamic(ref preds, _) => {
                 let unpacked_d = unpack_dyn_place(icx, d, preds).unwrap();
-                return do_default(mir, icx, unpacked_d.layout.ty, &unpacked_d);
+                return do_default(mir, icx, &unpacked_d);
             },
             _ => ()
         }
     }
 
     // Default case
-    return do_default(mir, icx, rty, d);
+    return do_default(mir, icx, d);
 }
 
 fn try_render_ref_opty<'tcx>(
     mir: &mut MirState<'_, 'tcx>,
     icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
     op_ty: &interpret::OpTy<'tcx>,
-    rty: ty::Ty<'tcx>,
     mutability: hir::Mutability,
 ) -> Option<serde_json::Value> {
     let tcx = mir.tcx;
@@ -1638,7 +1636,7 @@ fn try_render_ref_opty<'tcx>(
                 Some(alloc_id) => alloc_id.to_owned(),
                 None => {
                     // create the allocation
-                    let body = make_allocation_body(mir, icx, rty, &d, is_mut);
+                    let body = make_allocation_body(mir, icx, &d, is_mut);
                     mir.allocs.insert(tcx, ca, ty, body)
                 }
             };
@@ -1680,7 +1678,7 @@ fn try_render_ref_opty<'tcx>(
         // * Trait objects (&dyn Trait)
         //
         // These special cases and the ones in make_allocation_body above should be kept in sync.
-        match *rty.kind() {
+        match *d.layout.ty.kind() {
             ty::TyKind::Str | ty::TyKind::Slice(_) =>
                 return Some(do_slice(icx, &d, def_id_json)),
             ty::TyKind::Adt(adt_def, _) if tcx.is_lang_item(adt_def.did(), LangItem::CStr) =>

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -1384,7 +1384,7 @@ pub fn try_render_opty<'tcx>(
                     // If there are multiple with the same size we pick the
                     // first one.
                     if let Some((_,cur_sz,_)) = field_val {
-                       if cur_sz >= sz { continue }
+                        if cur_sz >= sz { continue }
                     }
                     match try_render_opty(mir, icx, &field) {
                         Ok(v) => field_val = Some((field_idx,sz,v)),
@@ -1393,11 +1393,11 @@ pub fn try_render_opty<'tcx>(
                     }
                 }
                 match field_val {
-                  None => return Err(RenderErr::Mismatch),
-                  Some((idx,_,val)) => {
-                    let js: serde_json::Value = val.into();
-                    json!({"kind": "union", "variant": idx.as_u32(), "val": js })
-                  }
+                    None => return Err(RenderErr::Mismatch),
+                    Some((idx,_,val)) => {
+                        let js: serde_json::Value = val.into();
+                        json!({"kind": "union", "variant": idx.as_u32(), "val": js })
+                    }
                 }
             },
         },

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -1236,29 +1236,48 @@ pub fn render_opty<'tcx>(
     icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
     op_ty: &interpret::OpTy<'tcx>,
 ) -> serde_json::Value {
-    try_render_opty(mir, icx, op_ty).unwrap_or_else(|| {
-        json!({
-            "kind": "unsupported_const",
-            "debug_val": format!("{:?}", op_ty),
-        })
+    try_render_opty(mir, icx, op_ty).unwrap_or_else(|err| {
+        match err {
+            RenderErr::Mismatch => panic!("Unexpexpected type mismatch"),
+            RenderErr::Unsupported =>
+                json!({
+                    "kind": "unsupported_const",
+                    "debug_val": format!("{:?}", op_ty),
+                })
+        }
     })
+}
+
+pub enum RenderErr { Mismatch, Unsupported }
+pub type Partial<T> = Result<T, RenderErr>;
+
+fn check_mismatch<'tcx,T>(x: InterpResult<'tcx,T>) -> Partial<T> {
+  match x.discard_err() {
+    None => Err(RenderErr::Mismatch),
+    Some(x) => Ok(x)
+  }
+}
+
+fn alloc_from_prov<'tcx>(tcx: TyCtxt<'tcx>, mb_prov: Option<interpret::CtfeProvenance>) -> Partial<interpret::GlobalAlloc<'tcx>> {
+    let prov = mb_prov.ok_or(RenderErr::Mismatch)?;
+    tcx.try_get_global_alloc(prov.alloc_id()).ok_or(RenderErr::Mismatch)
 }
 
 pub fn try_render_opty<'tcx>(
     mir: &mut MirState<'_, 'tcx>,
     icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
     op_ty: &interpret::OpTy<'tcx>,
-) -> Option<serde_json::Value> {
+) -> Partial<serde_json::Value> {
     let ty = op_ty.layout.ty;
     let layout = op_ty.layout.layout;
     let tcx = mir.tcx;
 
-    Some(match *ty.kind() {
+    Ok(match *ty.kind() {
         ty::TyKind::Bool |
         ty::TyKind::Char |
         ty::TyKind::Uint(_) =>
         {
-            let s = icx.read_immediate(op_ty).unwrap().to_scalar();
+            let s = check_mismatch(icx.read_immediate(op_ty))?.to_scalar();
             let size = layout.size();
             let bits = s.to_bits(size).unwrap();
 
@@ -1275,7 +1294,7 @@ pub fn try_render_opty<'tcx>(
             })
         }
         ty::TyKind::Int(_i) => {
-            let s = icx.read_immediate(op_ty).unwrap().to_scalar();
+            let s = check_mismatch(icx.read_immediate(op_ty))?.to_scalar();
             let size = layout.size();
             let bits = s.to_bits(size).unwrap();
             let mut val = bits as i128;
@@ -1295,7 +1314,7 @@ pub fn try_render_opty<'tcx>(
             })
         }
         ty::TyKind::Float(fty) => {
-            let s = icx.read_immediate(op_ty).unwrap().to_scalar();
+            let s = check_mismatch(icx.read_immediate(op_ty))?.to_scalar();
             let size = layout.size();
             let val_str = match fty {
                 ty::FloatTy::F16 => s.to_f16().unwrap().to_string(),
@@ -1338,13 +1357,13 @@ pub fn try_render_opty<'tcx>(
                     // We uphold `read_discriminant`'s precondition that the
                     // enum must be inhabited via the `is_uninhabited` check
                     // above.
-                    let variant_idx = icx.read_discriminant(op_ty).unwrap();
-                    let val = icx.project_downcast(op_ty, variant_idx).unwrap();
+                    let variant_idx = check_mismatch(icx.read_discriminant(op_ty))?;
+                    let val = check_mismatch(icx.project_downcast(op_ty, variant_idx))?;
                     let mut field_vals = Vec::with_capacity(val.layout.fields.count());
                     for idx in 0 .. val.layout.fields.count() {
                         let field_opty =
-                            icx.project_field(&val, FieldIdx::from_usize(idx)).unwrap();
-                        field_vals.push(try_render_opty(mir, icx,  &field_opty)?);
+                            check_mismatch(icx.project_field(&val, FieldIdx::from_usize(idx)))?;
+                        field_vals.push(try_render_opty(mir, icx, &field_opty)?);
                     }
 
                     json!({
@@ -1355,7 +1374,31 @@ pub fn try_render_opty<'tcx>(
                 }
             },
             ty::AdtKind::Union => {
-                json!({"kind": "union"})
+                let variant = adt_def.non_enum_variant();
+                let mut field_val = None;
+                for field_idx in variant.fields.indices() {
+                    let field = check_mismatch(icx.project_field(op_ty, field_idx))?;
+                    let sz    = field.layout.size;
+
+                    // We are looking for the largest interpretation that works
+                    // If there are multiple with the same size we pick the
+                    // first one.
+                    if let Some((_,cur_sz,_)) = field_val {
+                       if cur_sz >= sz { continue }
+                    }
+                    match try_render_opty(mir, icx, &field) {
+                        Ok(v) => field_val = Some((field_idx,sz,v)),
+                        Err(RenderErr::Mismatch) => (),
+                        Err(RenderErr::Unsupported) => return Err(RenderErr::Unsupported)
+                    }
+                }
+                match field_val {
+                  None => return Err(RenderErr::Mismatch),
+                  Some((idx,_,val)) => {
+                    let js: serde_json::Value = val.into();
+                    json!({"kind": "union", "variant": idx.as_u32(), "val": js })
+                  }
+                }
             },
         },
 
@@ -1364,9 +1407,9 @@ pub fn try_render_opty<'tcx>(
         ty::TyKind::Array(ety, sz) => {
             let sz = get_const_usize(tcx, sz);
             let mut vals = Vec::with_capacity(sz);
-            let mut iter = icx.project_array_fields(op_ty).unwrap();
+            let mut iter = check_mismatch(icx.project_array_fields(op_ty))?;
             while let Some((_, field)) = iter.next(icx).unwrap() {
-                let f_json = try_render_opty(mir, icx, &field);
+                let f_json = try_render_opty(mir, icx, &field)?;
                 vals.push(f_json);
             }
 
@@ -1390,8 +1433,8 @@ pub fn try_render_opty<'tcx>(
         ty::TyKind::Never => json!({"kind": "zst"}),
 
         ty::TyKind::FnPtr(_sig_tys, _hdr) => {
-            let ptr = icx.read_pointer(op_ty).unwrap();
-            let alloc = tcx.try_get_global_alloc(ptr.provenance?.alloc_id())?;
+            let ptr = check_mismatch(icx.read_pointer(op_ty))?;
+            let alloc = alloc_from_prov(tcx, ptr.provenance)?;
             match alloc {
                 interpret::GlobalAlloc::Function { instance } => {
                     let expected_abi = ty.fn_sig(tcx).abi();
@@ -1443,8 +1486,8 @@ pub fn try_render_opty<'tcx>(
             let mut vals = Vec::with_capacity(elts.len());
             for i in 0..elts.len() {
                 let fld: interpret::OpTy<'tcx> =
-                    icx.project_field(op_ty, FieldIdx::from_usize(i)).unwrap();
-                vals.push(render_opty(mir, icx, &fld));
+                    check_mismatch(icx.project_field(op_ty, FieldIdx::from_usize(i)))?;
+                vals.push(try_render_opty(mir, icx, &fld)?);
             }
             json!({
                 "kind": "tuple",
@@ -1464,10 +1507,10 @@ pub fn try_render_opty<'tcx>(
         ty::TyKind::Pat(ty, _) => {
             let inner_ty_and_layout = mir.tcx.layout_of(
                 ty::TypingEnv::fully_monomorphized().as_query_input(ty)).unwrap();
-            let new_op_ty = op_ty.transmute(inner_ty_and_layout, icx).unwrap();
+            let new_op_ty = check_mismatch(op_ty.transmute(inner_ty_and_layout, icx))?;
             return try_render_opty(mir, icx, &new_op_ty);
         },
-        ty::TyKind::UnsafeBinder(_unsafe_binder_inner) => {
+        ty::TyKind::UnsafeBinder(_unsafe_binder_inner) => {  // XXX: is this differnt from Err::Unsupported?
             json!({"kind": "unsupported"})
         },
     })
@@ -1478,14 +1521,14 @@ fn try_render_opty_upvars<'tcx>(
     icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
     op_ty: &interpret::OpTy<'tcx>,
     upvars_count: usize,
-) -> Option<Vec<serde_json::Value>> {
+) -> Partial<Vec<serde_json::Value>> {
     let mut upvar_vals = Vec::with_capacity(upvars_count);
     for idx in 0 .. upvars_count {
         let upvar_opty =
             icx.project_field(op_ty, FieldIdx::from_usize(idx)).unwrap();
         upvar_vals.push(try_render_opty(mir, icx, &upvar_opty)?);
     }
-    Some(upvar_vals)
+    Ok(upvar_vals)
 }
 
 /// Produce a `"kind": "constant"` JSON entry with all fields except `name`
@@ -1574,7 +1617,7 @@ fn make_allocation_body<'tcx>(
                 let mut elt_values = Vec::with_capacity(slice_len as usize);
                 for idx in 0..slice_len {
                     let elt = icx.project_index(&d.clone().into(), idx).unwrap();
-                    elt_values.push(try_render_opty(mir, icx, &elt));
+                    elt_values.push(render_opty(mir, icx, &elt));
                 }
                 // corresponding array type for contents
                 let aty = ty::Ty::new_array(tcx, slice_ty, slice_len);
@@ -1629,30 +1672,30 @@ fn try_render_ref_opty<'tcx>(
     icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
     op_ty: &interpret::OpTy<'tcx>,
     mutability: hir::Mutability,
-) -> Option<serde_json::Value> {
+) -> Partial<serde_json::Value> {
     let tcx = mir.tcx;
 
-    fn raw_ptr(offset: Size) -> Option<serde_json::Value> {
-        Some(json!({
+    fn raw_ptr(offset: Size) -> Partial<serde_json::Value> {
+        Ok(json!({
             "kind": "raw_ptr",
             "val": offset.bytes().to_string(),
         }))
     }
 
     // Special case for nullptr
-    let val = icx.read_immediate(op_ty).unwrap();
-    let mplace = icx.ref_to_mplace(&val).unwrap();
+    let val = check_mismatch(icx.read_immediate(op_ty))?;
+    let mplace = check_mismatch(icx.ref_to_mplace(&val))?;
     let (prov, offset) = mplace.ptr().into_raw_parts();
     if prov.is_none() {
         assert!(!mplace.meta().has_meta(), "not expecting meta for nullptr");
         return raw_ptr(offset);
     }
 
-    let d = icx.deref_pointer(op_ty).unwrap();
+    let d = check_mismatch(icx.deref_pointer(op_ty))?;
     let is_mut = mutability == hir::Mutability::Mut;
 
     let (prov, d_offset) = d.ptr().into_raw_parts();
-    let alloc = tcx.try_get_global_alloc(prov?.alloc_id())?;
+    let alloc = alloc_from_prov(tcx,prov)?;
 
     let def_id_json = match alloc {
         interpret::GlobalAlloc::Static(def_id) => {
@@ -1687,7 +1730,7 @@ fn try_render_ref_opty<'tcx>(
         }
         _ =>
             // Give up
-            return None
+            return Err(RenderErr::Unsupported)
     };
 
     // TODO(#241): Lift this restriction.
@@ -1720,9 +1763,9 @@ fn try_render_ref_opty<'tcx>(
         // These special cases and the ones in make_allocation_body above should be kept in sync.
         match *d.layout.ty.kind() {
             ty::TyKind::Str | ty::TyKind::Slice(_) =>
-                return Some(do_slice(icx, &d, def_id_json)),
+                return Ok(do_slice(icx, &d, def_id_json)),
             ty::TyKind::Adt(adt_def, _) if tcx.is_lang_item(adt_def.did(), LangItem::CStr) =>
-                return Some(do_slice(icx, &d, def_id_json)),
+                return Ok(do_slice(icx, &d, def_id_json)),
             ty::TyKind::Dynamic(ref preds, _) => {
                 let self_ty = unpack_dyn_ty(icx, &d, preds).unwrap();
                 let vtable_desc = preds.principal().map(|pred| pred.with_self_ty(tcx, self_ty));
@@ -1730,7 +1773,7 @@ fn try_render_ref_opty<'tcx>(
                     Some(vtable_desc) => {
                         mir.used.vtables.insert(vtable_desc);
                         let ti = TraitInst::from_dynamic_predicates(tcx, preds);
-                        return Some(json!({
+                        return Ok(json!({
                             "kind": "trait_object",
                             "def_id": def_id_json,
                             "trait_id": trait_inst_id_str(tcx, &ti),
@@ -1742,7 +1785,7 @@ fn try_render_ref_opty<'tcx>(
                         // the trait bounds are auto traits. We do not
                         // currently support computing vtables for these sorts
                         // of trait objects (see #239).
-                        return Some(json!({
+                        return Ok(json!({
                             "kind": "unsupported",
                         }))
                 }
@@ -1751,7 +1794,7 @@ fn try_render_ref_opty<'tcx>(
         }
     }
 
-    return Some(json!({
+    return Ok(json!({
         "kind": "static_ref",
         "def_id": def_id_json,
     }));

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -1241,14 +1241,24 @@ pub fn render_opty<'tcx>(
             RenderErr::Mismatch => panic!("Unexpexpected type mismatch"),
             RenderErr::Unsupported =>
                 json!({
-                    "kind": "unsupported_const",
+                    "kind": "unsupported",
                     "debug_val": format!("{:?}", op_ty),
                 })
         }
     })
 }
 
-pub enum RenderErr { Mismatch, Unsupported }
+
+/// Errors that may occur while interpreting bytes as a value of a specific type
+pub enum RenderErr {
+    /// Indicates that the bytes do not match the given type
+    Mismatch,
+
+    /// Indicates that we encountered a type that we don't know how to process
+    Unsupported
+}
+
+/// The result may fail due to rendering errors
 pub type Partial<T> = Result<T, RenderErr>;
 
 fn check_mismatch<'tcx,T>(x: InterpResult<'tcx,T>) -> Partial<T> {
@@ -1510,8 +1520,8 @@ pub fn try_render_opty<'tcx>(
             let new_op_ty = check_mismatch(op_ty.transmute(inner_ty_and_layout, icx))?;
             return try_render_opty(mir, icx, &new_op_ty);
         },
-        ty::TyKind::UnsafeBinder(_unsafe_binder_inner) => {  // XXX: is this differnt from Err::Unsupported?
-            json!({"kind": "unsupported"})
+        ty::TyKind::UnsafeBinder(_unsafe_binder_inner) => {
+            return Err(RenderErr::Unsupported)
         },
     })
 }

--- a/src/schema_ver.rs
+++ b/src/schema_ver.rs
@@ -6,4 +6,4 @@
 /// Each version of the schema is assumed to be backwards-incompatible with
 /// previous versions of the schema. As such, any time this version number is
 /// bumped, it should be treated as a major version bump.
-pub const SCHEMA_VER: u64 = 12;
+pub const SCHEMA_VER: u64 = 13;

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -34,6 +34,33 @@ expect_json_contains() {
   fi
 }
 
+# Usage: expect_static_matches <name-suffix> <expected-json>
+#
+# Match the shape of the .statics[] entry ending with <name-suffix> in
+# test.linked-mir.json against <expected-json>, ignoring volatile fields.
+expect_static_matches() {
+  local suffix="$1"
+  local expected="$2"
+  local file=test.linked-mir.json
+
+  local actual
+  actual=$(jq --arg n "$suffix" \
+    '.statics[]
+       | select(.name | endswith($n))
+       | del(.name, .ty, .rendered.def_id, .rendered.element_ty)' \
+    "$file")
+
+  if [[ -z "$actual" ]]; then
+    echo "ERROR: no .statics[] entry with name ending in '$suffix' in $file"
+    exit 1
+  fi
+
+  if ! diff <(echo "$expected" | jq -S .) <(echo "$actual" | jq -S .); then
+    echo "ERROR: shape of static '$suffix' did not match expected"
+    exit 1
+  fi
+}
+
 expect_output_does_not_contain() {
   set +e
   output=$("${@:2}" 2>&1)

--- a/tests/regression/test_statics/test.rs
+++ b/tests/regression/test_statics/test.rs
@@ -1,0 +1,59 @@
+#![feature(thread_local)]
+
+// Ordinary immutable static.
+pub static ORDINARY: u32 = 42;
+
+// Mutable static.
+pub static mut MUT_STATIC: u32 = 7;
+
+// Static referencing a string literal (creates an anonymous {{alloc}}).
+pub static STR_REF: &str = "hi";
+
+// Nested static: rustc invents an anonymous nested static for the inner
+// `&LEAF` reference because the outer initializer takes a `&` to a
+// `const` that itself contains a `&`. See `Note [Nested statics]` in
+// analyz/mod.rs for the mechanism.
+pub const LEAF: &[u64] = &[42];
+pub static NESTED_OUTER: &[&[u64]] = &[&LEAF];
+
+// Thread-local static (with an initializer).
+#[thread_local]
+pub static TLS_COUNTER: u32 = 3;
+
+// Thread-local static whose initializer is a reference to a promoted
+// literal. The `&0` is const-promoted (not lifted to a nested static)
+// so `TLS_REF` ends up holding a pointer into an anonymous
+// `GlobalAlloc::Memory` allocation.
+#[thread_local]
+pub static TLS_REF: &u32 = &0;
+
+// Slice literals are like STR_REF in that it points into an anonymous
+// allocation, but the renderer treats slices structurally (rendering
+// each element via `try_render_opty`) rather than as an opaque byte
+// buffer, so this exercises a separate arm from the string case.
+pub static ARR_REF: &[u8] = &[1, 2, 3];
+
+// `static mut` with a compound value. Exercises `make_allocation_body`
+// with `is_mut = true`, distinct from `MUT_STATIC` (primitive) above.
+pub static mut MUT_ARR: [u32; 3] = [1, 2, 3];
+
+// Function-pointer static. Exercises the `FnPtr` arm of
+// `try_render_opty`, and confirms that `mir.used.instances` gets
+// populated for functions reached only via constant statics.
+fn fn_ptr_target() -> u32 { 100 }
+pub static FN_PTR: fn() -> u32 = fn_ptr_target;
+
+// Force each static to be used so it appears in mono items.
+pub fn touch_all() -> u32 {
+    let mut_val = unsafe { MUT_STATIC };
+    let mut_arr_val = unsafe { MUT_ARR[0] };
+    ORDINARY
+        .wrapping_add(mut_val)
+        .wrapping_add(STR_REF.len() as u32)
+        .wrapping_add(NESTED_OUTER.len() as u32)
+        .wrapping_add(TLS_COUNTER)
+        .wrapping_add(*TLS_REF)
+        .wrapping_add(ARR_REF[0] as u32)
+        .wrapping_add(mut_arr_val)
+        .wrapping_add(FN_PTR())
+}

--- a/tests/regression/test_statics/test.sh
+++ b/tests/regression/test_statics/test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/../../common.sh"
+
+expect_no_panic saw-rustc test.rs --target "$(rustc --print host-tuple)"
+
+# Target-shape assertions for issue #177. Each static should appear in
+# .statics[] as kind:"constant", with `rendered` carrying the
+# initializer's ConstVal.
+#
+# `expect_static_matches` strips volatile fields (`name`, `ty`,
+# `rendered.def_id`) before comparing, so these expected values describe
+# the *shape* of each static independent of crate-hash and alloc-id churn.
+
+expect_static_matches "::ORDINARY" '{
+  "kind": "constant",
+  "mutable": false,
+  "rendered": { "kind": "uint", "size": 4, "val": "42" }
+}'
+
+expect_static_matches "::MUT_STATIC" '{
+  "kind": "constant",
+  "mutable": true,
+  "rendered": { "kind": "uint", "size": 4, "val": "7" }
+}'
+
+# String literal — anonymous {{alloc}} rendered as `strbody`.
+expect_static_matches "::STR_REF" '{
+  "kind": "constant",
+  "mutable": false,
+  "rendered": { "kind": "slice", "len": 2 }
+}'
+
+# Nested static via `&const_item` inlining — the outer holds a slice
+# pointing at an anonymous nested-static allocation.
+expect_static_matches "::NESTED_OUTER" '{
+  "kind": "constant",
+  "mutable": false,
+  "rendered": { "kind": "slice", "len": 1 }
+}'
+
+# Thread-local primitive.
+expect_static_matches "::TLS_COUNTER" '{
+  "kind": "constant",
+  "mutable": false,
+  "rendered": { "kind": "uint", "size": 4, "val": "3" }
+}'
+
+# Thread-local reference to a const-promoted literal. Renders as a
+# static_ref to the anonymous alloc holding the u32.
+expect_static_matches "::TLS_REF" '{
+  "kind": "constant",
+  "mutable": false,
+  "rendered": { "kind": "static_ref" }
+}'
+
+# Slice literal — structurally rendered as an `array` of three bytes.
+expect_static_matches "::ARR_REF" '{
+  "kind": "constant",
+  "mutable": false,
+  "rendered": { "kind": "slice", "len": 3 }
+}'
+
+# `static mut` with a compound value — exercises make_allocation_body
+# with is_mut = true. Arrays with inline initializers render their
+# elements structurally rather than as a slice-into-alloc.
+expect_static_matches "::MUT_ARR" '{
+  "kind": "constant",
+  "mutable": true,
+  "rendered": {
+    "kind": "array",
+    "elements": [
+      { "kind": "uint", "size": 4, "val": "1" },
+      { "kind": "uint", "size": 4, "val": "2" },
+      { "kind": "uint", "size": 4, "val": "3" }
+    ]
+  }
+}'
+
+# Function-pointer static — rendered value points at the callee's DefId.
+expect_static_matches "::FN_PTR" '{
+  "kind": "constant",
+  "mutable": false,
+  "rendered": { "kind": "fn_ptr" }
+}'
+
+# The callee referenced by FN_PTR must appear in `fns` (populated via
+# `mir.used.instances`).
+expect_json_contains \
+  '.fns[] | select(.name | test("::fn_ptr_target$"))' \
+  test.linked-mir.json


### PR DESCRIPTION
Fixes #177 by implementing the plan outlined in the discussion on this issue. 

Claude helped quite a bit with this PR, so it's possible it made some stuff up---I don't see anything that's wrong, so as far as I understand the implementation matches the suggestions from the issue, but we should be fairly careful with the review of this PR, as I am very new to working with the `rustc` API, so it is quite possible I am misunderstanding some of the details.

Also note that this is on top of `rgs/constant-eval-refactoroing`