### PR TITLE
`libs`: Remove patches made obsolete by `MirAggregate` flattening

### DIFF
--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -258,16 +258,6 @@ into the main commit for that patch, and then the *Update* line can be removed.
   back to using the global allocator instead.  We already don't support custom
   global allocators, so this shouldn't cause any problems.
 
-* Add `{Arc,Rc}::{from,into}_inner_raw` API functions (last applied: June 12, 2026)
-
-  `crucible-mir` is not currently able to simulate the
-  `{Arc,Rc}::{from,into}_raw` functions, as they rely on non-trivial pointer
-  offsets plus read from type-casted pointers.
-  `{Arc,Rc}::{from,into}_inner_raw` offer alternatives with very similar types,
-  but which are implemented in a Crucible-friendly way.
-
-  See also the "`{Arc,Rc}::{from,into}_inner_raw`" below.
-
 * Don't use a `union` in `LazyLock`'s internals (last applied June 12, 2026)
 
   The internals of `std::sync::LazyLock` use a `union` value to distinguish
@@ -385,54 +375,3 @@ Using the `PartialEq` impl for raw pointers works better in a `crucible-mir`
 context. Instead of raising a simulation error, `crucible-mir` will simply
 return `False` when checking if a `MirReference_Integer` is equal to a valid
 `MirReference`.
-
-## `{Arc,Rc}::{from,into}_inner_raw`
-
-`crucible-mir` is not currently able to simulate the
-`{Arc,Rc}::{from,into}_raw` functions. This is because they subtract a constant
-offset from a `*T` pointer in order to obtain a pointer of type
-`*ArcInner<T>`/`*RcInner<T>`. This sort of pointer arithmetic is permitted in
-Rust, but `crucible-mir`'s memory model is not yet sophisticated enough to
-support this.
-
-As a workaround, we offer `{Arc,Rc}::{from,into}_inner_raw` API functions,
-which work directly on `*ArcInner<T>`/`*RcInner<T>` pointers instead of `*T`
-pointers, thereby avoiding the need for problematic pointer casts. This is not
-a perfect solution, as these functions will not work as drop-in replacements
-for `{Arc,Rc}::{from,into}_raw` in all situations due to the differences in
-types. Where they _do_ work as drop-in replacements are situations where a call
-to `{Arc,Rc}::into_raw` is followed by another call to `{Arc,Rc}::from_raw`,
-without reading the intermediate raw pointer in between. For instance, in the
-following example (taken from the [documentation for
-`Arc::from_raw`](https://doc.rust-lang.org/1.91.0/std/sync/struct.Arc.html#method.from_raw)):
-
-```rs
-use std::sync::Arc;
-
-let x = Arc::new("hello".to_owned());
-let x_ptr = Arc::into_raw(x);
-
-unsafe {
-    // Convert back to an `Arc` to prevent leak.
-    let x = Arc::from_raw(x_ptr);
-    assert_eq!(&*x, "hello");
-
-    // Further calls to `Arc::from_raw(x_ptr)` would be memory-unsafe.
-}
-```
-
-The calls to `Arc::{from,into}_raw` can be replaced with
-`Arc::{from,into}_inner_raw` with no change in functionality. This sort of
-pattern occurs fairly often in practice, so it is worth having at least some
-support for it. For example, the internals of `std::thread` also construct
-`Arc` values in a very similar fashion, so we also patch `std::thread` to use
-`Arc::{from,into}_inner_raw`.
-
-(An API design note: because `{Arc,Rc}::{from,into}_inner_raw` are exposed as
-part of the public API, we must also expose the (previously internal)
-`ArcInner` and `RcInner` types as a consequence.)
-
-Once `crucible-mir` finishes migrating to use `MirAggregate` (see
-https://github.com/GaloisInc/crucible/issues/1499), it should be able to
-simulate `{Arc,Rc}::{from,into}_raw` properly, which would allow us to remove
-`{Arc,Rc}::{from,into}_inner_raw`.

--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -212,14 +212,6 @@ into the main commit for that patch, and then the *Update* line can be removed.
   time to a fixed date), but it does simulate much more easily than the actual
   implementation.
 
-* Replace `{*mut,NonNull}::cast` with `transmute` in `RawVec` initialization (last applied: June 10, 2026)
-
-  `RawVec` casts `*mut T` to `*mut u8` to store it with the type erased, and
-  casts back later before dereferencing.  When `T = [u8; N]`, Crucible handles
-  the `*mut [u8; N]` to `*mut u8` cast by inserting an indexing projection,
-  which is unwanted here and results in an invalid reference after casting
-  back.
-
 * Always use regular `sleep` in `std::sys::thread::unix::sleep_until` (last applied: June 10, 2026)
 
   The `sleep_until` implementation on unix tries to use `clock_nanosleep` when

--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -327,6 +327,20 @@ patch. Alternatively, if you choose to deviate from the note, make sure to do
 so after carefully considering why deviating is the right choice, and consider
 updating the note in the process.
 
+## Mark hook functions as `#[inline(never)]`
+
+We want to ensure that custom hook functions (e.g.,
+`crucible_null_hook`) are always present in generated MIR code,
+regardless of whether or not optimizations are applied. In some cases, it may
+not suffice to compile the code containing the hook functions without
+optimizations (as `mir-json-translate-libs` currently does), as `rustc` can
+still inline code that is contained in a different compilation unit. (See
+[#153](https://github.com/GaloisInc/mir-json/issues/153) for an example where
+this actually happened.)
+
+As a safeguard, we mark all custom hook functions as `#[inline(never)]` to
+ensure that they persist when optimizations are applied.
+
 ## Avoid raw pointer comparisons
 
 We avoid using `PartialOrd`-based comparisons with raw pointers values, e.g.,

--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -268,12 +268,6 @@ into the main commit for that patch, and then the *Update* line can be removed.
 
   See also the "`{Arc,Rc}::{from,into}_inner_raw`" below.
 
-* Use `Arc::{from,into}_inner_raw` in `Thread` implementation (last applied: June 12, 2026)
-
-  This avoids issues with `thread::current()`, which creates a `Thread` handle
-  on first use and stores it as `*const ()` in a thread-local variable for
-  later use.
-
 * Don't use a `union` in `LazyLock`'s internals (last applied June 12, 2026)
 
   The internals of `std::sync::LazyLock` use a `union` value to distinguish

--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -43,21 +43,6 @@ into the main commit for that patch, and then the *Update* line can be removed.
 
   The actual implementation uses a pointer cast that Crucible can't handle.
 
-* Add a hook for the cast in `std::slice::as_chunks_unchecked(_mut)` (last applied June 9, 2026)
-
-  These functions convert `&[T]` to `&[[T; N]]`, which internally involves a
-  cast from `*const T` to `*const [T; N]` that the current crux-mir memory
-  model doesn't support in general.  This patch adds a hook for the cast so we
-  can implement it using crux-mir's new `AggregateAsChunks_RefPath` feature,
-  which is a special case designed specifically for `<[_]>::as_chunks`.
-
-  Given this capability the following functions are then rewritten in terms of
-  `as_chunks_unchecked(_mut)`: `first_chunk(_mut)`, `split_first_chunk(_mut)`,
-  `last_chunk(_mut)`, `split_last_chunk(_mut)`, `slice::as(_mut)_array`.
-
-  See also the "Limitations of zero-length arrays and
-  `slice::as_chunks_unchecked(_mut)`" note below.
-
 * Avoid `transmute` in `Layout` and `Alignment` (last applied: June 9, 2026)
 
   `Alignment::new_unchecked` uses `transmute` to convert an integer to an enum
@@ -372,50 +357,6 @@ notes, please make sure that the spirit of the note is still upheld in the new
 patch. Alternatively, if you choose to deviate from the note, make sure to do
 so after carefully considering why deviating is the right choice, and consider
 updating the note in the process.
-
-## Mark hook functions as `#[inline(never)]`
-
-We want to ensure that custom hook functions (e.g.,
-`crucible_null_hook`) are always present in generated MIR code,
-regardless of whether or not optimizations are applied. In some cases, it may
-not suffice to compile the code containing the hook functions without
-optimizations (as `mir-json-translate-libs` currently does), as `rustc` can
-still inline code that is contained in a different compilation unit. (See
-[#153](https://github.com/GaloisInc/mir-json/issues/153) for an example where
-this actually happened.)
-
-As a safeguard, we mark all custom hook functions as `#[inline(never)]` to
-ensure that they persist when optimizations are applied.
-
-## Limitations of zero-length arrays and `slice::as_chunks_unchecked(_mut)`
-
-One of the reasons why we override `slice::as_chunks_unchecked(_mut)` is so
-that we can guarantee that the input reference aliases the output reference.
-Currently, this requires custom overrides in `crucible-mir` to accomplish.
-Moreover, we can define many similar-looking functions in terms of
-`slice::as_chunks_unchecked(_mut)`, which allows us to get away with only
-defining two custom overrides.
-
-Unfortunately, this approach has a notable drawback. We define functions such
-as `slice::as(_mut)_array` in terms of `slice::as_chunks_unchecked(_mut)`, but
-while the former functions work for arrays of any length, the latter functions
-have a precondition that the array length is non-zero. This means that if we
-call `slice::as(_mut)_array` with an array length of zero, then we cannot call
-`slice::as_chunks_unchecked(_mut)` and must use a different approach.
-
-One possible way to go about this would be to give `slice::as(_mut)_array` and
-friends additional custom overrides to handle the length-0 cases. This is
-doable, but it would be annoying to maintain, given that we would need to add a
-significant amount of additional special-casing. What's more, we are planning
-to remove these special cases later once the migration to `MirAggregate` is
-finished (see https://github.com/GaloisInc/crucible/issues/1499), so it feels
-wasteful to invest in this kind of solution.
-
-We instead adopt a less correct but much cheaper solution: when the array
-length is zero, simply return `&[]` or `&mut []`. This sort of output reference
-will _not_ alias the input reference, but since the output has no actual
-elements, the lack of aliasing is hard to observe. As such, this compromise is
-likely fine for most use cases.
 
 ## Avoid raw pointer comparisons
 

--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -174,13 +174,6 @@ into the main commit for that patch, and then the *Update* line can be removed.
   `core::ptr::without_provenance`, which uses an int-to-pointer transmute
   instead.
 
-* Remove the use of `ptr::from_raw_parts` from `ptr::null` (last applied: June 10, 2026)
-
-  The `ptr::from_raw_parts` function implicitly performs a pointer cast through
-  the `AggregateKind::RawPtr` intrinsic, which crucible-mir does not support for
-  non-slice types. This patch removes direct calls to `ptr::from_raw_parts` from
-  `ptr::null` and `ptr::null_mut`.
-
 * Use hooks in `core::slice::from_ref` and `from_mut` (last applied: June 10, 2026)
 
   The actual implementations use pointer casts that Crucible can't handle.

--- a/libs/alloc/src/raw_vec/mod.rs
+++ b/libs/alloc/src/raw_vec/mod.rs
@@ -282,7 +282,7 @@ impl<T, A: Allocator> RawVec<T, A> {
     pub(crate) const unsafe fn from_raw_parts_in(ptr: *mut T, capacity: usize, alloc: A) -> Self {
         // SAFETY: Precondition passed to the caller
         unsafe {
-            let ptr = core::mem::transmute::<*mut T, *mut u8>(ptr);
+            let ptr = ptr.cast();
             let capacity = new_cap::<T>(capacity);
             let inner_alloc = crucible::TypedAllocator::NEW;
             Self {
@@ -303,7 +303,7 @@ impl<T, A: Allocator> RawVec<T, A> {
     pub(crate) const unsafe fn from_nonnull_in(ptr: NonNull<T>, capacity: usize, alloc: A) -> Self {
         // SAFETY: Precondition passed to the caller
         unsafe {
-            let ptr = core::mem::transmute::<NonNull<T>, NonNull<u8>>(ptr);
+            let ptr = ptr.cast();
             let capacity = new_cap::<T>(capacity);
             let inner_alloc = crucible::TypedAllocator::new();
             Self {

--- a/libs/alloc/src/rc.rs
+++ b/libs/alloc/src/rc.rs
@@ -282,8 +282,7 @@ use crate::vec::Vec;
 // repr(align(2)) (forcing alignment to at least 2) is required because usize
 // has 1-byte alignment on AVR.
 #[repr(C, align(2))]
-#[stable(feature = "rc_raw", since = "1.17.0")]
-pub struct RcInner<T: ?Sized> {
+struct RcInner<T: ?Sized> {
     strong: Cell<usize>,
     weak: Cell<usize>,
     value: T,
@@ -1471,16 +1470,6 @@ impl<T: ?Sized> Rc<T> {
         unsafe { Self::from_raw_in(ptr, Global) }
     }
 
-    /// Like [`from_raw`], except that this function accepts an `RcInner<T>`
-    /// pointer instead of a `T` pointer. This is meant to serve as a
-    /// replacement for [`from_raw`] (to be used in conjunction with
-    /// [`into_inner_raw`]) that is feasible for `crucible-mir` to simulate.
-    #[inline]
-    #[stable(feature = "rc_raw", since = "1.17.0")]
-    pub unsafe fn from_inner_raw(ptr: *const RcInner<T>) -> Self {
-        unsafe { Rc::from_ptr(ptr as *mut RcInner<T>) }
-    }
-
     /// Consumes the `Rc`, returning the wrapped pointer.
     ///
     /// To avoid a memory leak the pointer must be converted back to an `Rc` using
@@ -1503,18 +1492,6 @@ impl<T: ?Sized> Rc<T> {
     pub fn into_raw(this: Self) -> *const T {
         let this = ManuallyDrop::new(this);
         Self::as_ptr(&*this)
-    }
-
-    /// Like [`into_raw`], except that this function returns an `RcInner<T>`
-    /// pointer instead of a `T` pointer. This is meant to serve as a
-    /// replacement for [`into_raw`] (to be used in conjunction with
-    /// [`from_inner_raw`]) that is feasible for `crucible-mir` to simulate.
-    #[must_use = "losing the pointer will leak memory"]
-    #[stable(feature = "rc_raw", since = "1.17.0")]
-    #[rustc_never_returns_null_ptr]
-    pub fn into_inner_raw(this: Self) -> *const RcInner<T> {
-        let this = ManuallyDrop::new(this);
-        this.ptr.as_ptr() as *const RcInner<T>
     }
 
     /// Increments the strong reference count on the `Rc<T>` associated with the

--- a/libs/alloc/src/sync.rs
+++ b/libs/alloc/src/sync.rs
@@ -380,8 +380,7 @@ impl<T: ?Sized, A: Allocator> fmt::Debug for Weak<T, A> {
 // Unlike RcInner, repr(align(2)) is not strictly required because atomic types
 // have the alignment same as its size, but we use it for consistency and clarity.
 #[repr(C, align(2))]
-#[stable(feature = "rc_raw", since = "1.17.0")]
-pub struct ArcInner<T: ?Sized> {
+struct ArcInner<T: ?Sized> {
     strong: Atomic<usize>,
 
     // the value usize::MAX acts as a sentinel for temporarily "locking" the
@@ -401,9 +400,7 @@ fn arcinner_layout_for_value_layout(layout: Layout) -> Layout {
     Layout::new::<ArcInner<()>>().extend(layout).unwrap().0.pad_to_align()
 }
 
-#[stable(feature = "rc_raw", since = "1.17.0")]
 unsafe impl<T: ?Sized + Sync + Send> Send for ArcInner<T> {}
-#[stable(feature = "rc_raw", since = "1.17.0")]
 unsafe impl<T: ?Sized + Sync + Send> Sync for ArcInner<T> {}
 
 impl<T> Arc<T> {
@@ -1624,16 +1621,6 @@ impl<T: ?Sized> Arc<T> {
         unsafe { Arc::from_raw_in(ptr, Global) }
     }
 
-    /// Like [`from_raw`], except that this function accepts an `ArcInner<T>`
-    /// pointer instead of a `T` pointer. This is meant to serve as a
-    /// replacement for [`from_raw`] (to be used in conjunction with
-    /// [`into_inner_raw`]) that is feasible for `crucible-mir` to simulate.
-    #[inline]
-    #[stable(feature = "rc_raw", since = "1.17.0")]
-    pub unsafe fn from_inner_raw(ptr: *const ArcInner<T>) -> Self {
-        unsafe { Arc::from_ptr(ptr as *mut ArcInner<T>) }
-    }
-
     /// Consumes the `Arc`, returning the wrapped pointer.
     ///
     /// To avoid a memory leak the pointer must be converted back to an `Arc` using
@@ -1656,18 +1643,6 @@ impl<T: ?Sized> Arc<T> {
     pub fn into_raw(this: Self) -> *const T {
         let this = ManuallyDrop::new(this);
         Self::as_ptr(&*this)
-    }
-
-    /// Like [`into_raw`], except that this function returns an `ArcInner<T>`
-    /// pointer instead of a `T` pointer. This is meant to serve as a
-    /// replacement for [`into_raw`] (to be used in conjunction with
-    /// [`from_inner_raw`]) that is feasible for `crucible-mir` to simulate.
-    #[must_use = "losing the pointer will leak memory"]
-    #[stable(feature = "rc_raw", since = "1.17.0")]
-    #[rustc_never_returns_null_ptr]
-    pub fn into_inner_raw(this: Self) -> *const ArcInner<T> {
-        let this = ManuallyDrop::new(this);
-        this.ptr.as_ptr() as *const ArcInner<T>
     }
 
     /// Increments the strong reference count on the `Arc<T>` associated with the

--- a/libs/core/src/ptr/mod.rs
+++ b/libs/core/src/ptr/mod.rs
@@ -839,10 +839,7 @@ where
 #[rustc_const_stable(feature = "const_ptr_null", since = "1.24.0")]
 #[rustc_diagnostic_item = "ptr_null"]
 pub const fn null<T: PointeeSized + Thin>() -> *const T {
-    const fn crucible_null_hook<T: PointeeSized + Thin>() -> *const T {
-        from_raw_parts(without_provenance::<()>(0), ())
-    }
-    crucible_null_hook()
+    from_raw_parts(without_provenance::<()>(0), ())
 }
 
 /// Creates a null mutable raw pointer.
@@ -867,10 +864,7 @@ pub const fn null<T: PointeeSized + Thin>() -> *const T {
 #[rustc_const_stable(feature = "const_ptr_null", since = "1.24.0")]
 #[rustc_diagnostic_item = "ptr_null_mut"]
 pub const fn null_mut<T: PointeeSized + Thin>() -> *mut T {
-    const fn crucible_null_hook<T: PointeeSized + Thin>() -> *mut T {
-        from_raw_parts_mut(without_provenance_mut::<()>(0), ())
-    }
-    crucible_null_hook()
+    from_raw_parts_mut(without_provenance_mut::<()>(0), ())
 }
 
 /// Creates a pointer with the given address and no [provenance][crate::ptr#provenance].

--- a/libs/core/src/slice/mod.rs
+++ b/libs/core/src/slice/mod.rs
@@ -10,7 +10,7 @@ use crate::clone::TrivialClone;
 use crate::cmp::Ordering::{self, Equal, Greater, Less};
 use crate::intrinsics::{exact_div, unchecked_sub};
 use crate::marker::Destruct;
-use crate::mem::{self, MaybeUninit, SizedTypeProperties, transmute};
+use crate::mem::{self, MaybeUninit, SizedTypeProperties};
 use crate::num::NonZero;
 use crate::ops::{OneSidedRange, OneSidedRangeBound, Range, RangeBounds, RangeInclusive};
 use crate::panic::const_panic;
@@ -330,7 +330,7 @@ impl<T> [T] {
         } else {
             // SAFETY: We explicitly check for the correct number of elements,
             //   and do not let the reference outlive the slice.
-            Some(self.split_at(N).0.as_array().unwrap())
+            Some(unsafe { &*(self.as_ptr().cast_array()) })
         }
     }
 
@@ -361,7 +361,7 @@ impl<T> [T] {
             // SAFETY: We explicitly check for the correct number of elements,
             //   do not let the reference outlive the slice,
             //   and require exclusive access to the entire slice to mutate the chunk.
-            Some(self.split_at_mut(N).0.as_mut_array().unwrap())
+            Some(unsafe { &mut *(self.as_mut_ptr().cast_array()) })
         }
     }
 
@@ -389,7 +389,7 @@ impl<T> [T] {
 
         // SAFETY: We explicitly check for the correct number of elements,
         //   and do not let the references outlive the slice.
-        Some((first.as_array().unwrap(), tail))
+        Some((unsafe { &*(first.as_ptr().cast_array()) }, tail))
     }
 
     /// Returns a mutable array reference to the first `N` items in the slice and the remaining
@@ -422,7 +422,7 @@ impl<T> [T] {
         // SAFETY: We explicitly check for the correct number of elements,
         //   do not let the reference outlive the slice,
         //   and enforce exclusive mutability of the chunk by the split.
-        Some((first.as_mut_array().unwrap(), tail))
+        Some((unsafe { &mut *(first.as_mut_ptr().cast_array()) }, tail))
     }
 
     /// Returns an array reference to the last `N` items in the slice and the remaining slice.
@@ -450,7 +450,7 @@ impl<T> [T] {
 
         // SAFETY: We explicitly check for the correct number of elements,
         //   and do not let the references outlive the slice.
-        Some((init, last.as_array().unwrap()))
+        Some((init, unsafe { &*(last.as_ptr().cast_array()) }))
     }
 
     /// Returns a mutable array reference to the last `N` items in the slice and the remaining
@@ -484,7 +484,7 @@ impl<T> [T] {
         // SAFETY: We explicitly check for the correct number of elements,
         //   do not let the reference outlive the slice,
         //   and enforce exclusive mutability of the chunk by the split.
-        Some((init, last.as_mut_array().unwrap()))
+        Some((init, unsafe { &mut *(last.as_mut_ptr().cast_array()) }))
     }
 
     /// Returns an array reference to the last `N` items in the slice.
@@ -513,7 +513,7 @@ impl<T> [T] {
 
         // SAFETY: We explicitly check for the correct number of elements,
         //   and do not let the references outlive the slice.
-        Some(last.as_array().unwrap())
+        Some(unsafe { &*(last.as_ptr().cast_array()) })
     }
 
     /// Returns a mutable array reference to the last `N` items in the slice.
@@ -544,7 +544,7 @@ impl<T> [T] {
         // SAFETY: We explicitly check for the correct number of elements,
         //   do not let the reference outlive the slice,
         //   and require exclusive access to the entire slice to mutate the chunk.
-        Some(last.as_mut_array().unwrap())
+        Some(unsafe { &mut *(last.as_mut_ptr().cast_array()) })
     }
 
     /// Returns a reference to an element or subslice depending on the type of
@@ -849,17 +849,11 @@ impl<T> [T] {
     #[must_use]
     pub const fn as_array<const N: usize>(&self) -> Option<&[T; N]> {
         if self.len() == N {
-            if N == 0 {
-                // `as_chunks_unchecked` only works for non-zero array lengths,
-                // so we employ a special case here. Note that the `N == 0`
-                // check is performed at runtime, not compile time, so the
-                // types [T; 0] and [T; N] do not match. As such, we must use
-                // `transmute` to convince the typechecker.
-                let a: &[T; 0] = &[];
-                unsafe { Some(transmute(a)) }
-            } else {
-                unsafe { Some(&self.as_chunks_unchecked()[0]) }
-            }
+            let ptr = self.as_ptr().cast_array();
+
+            // SAFETY: The underlying array of a slice can be reinterpreted as an actual array `[T; N]` if `N` is not greater than the slice's length.
+            let me = unsafe { &*ptr };
+            Some(me)
         } else {
             None
         }
@@ -874,17 +868,11 @@ impl<T> [T] {
     #[must_use]
     pub const fn as_mut_array<const N: usize>(&mut self) -> Option<&mut [T; N]> {
         if self.len() == N {
-            if N == 0 {
-                // `as_chunks_unchecked_mut` only works for non-zero array lengths,
-                // so we employ a special case here. Note that the `N == 0`
-                // check is performed at runtime, not compile time, so the
-                // types [T; 0] and [T; N] do not match. As such, we must use
-                // `transmute` to convince the typechecker.
-                let a: &mut [T; 0] = &mut [];
-                unsafe { Some(transmute(a)) }
-            } else {
-                unsafe { Some(&mut self.as_chunks_unchecked_mut()[0]) }
-            }
+            let ptr = self.as_mut_ptr().cast_array();
+
+            // SAFETY: The underlying array of a slice can be reinterpreted as an actual array `[T; N]` if `N` is not greater than the slice's length.
+            let me = unsafe { &mut *ptr };
+            Some(me)
         } else {
             None
         }
@@ -1355,19 +1343,9 @@ impl<T> [T] {
         );
         // SAFETY: Caller must guarantee that `N` is nonzero and exactly divides the slice length
         let new_len = unsafe { exact_div(self.len(), N) };
-
-        /// Given a pointer to the first of `new_len * N` elements, view the elements as `new_len`
-        /// arrays of `N` elements each, and return a pointer to the first of the arrays.
-        #[inline(never)] // Keep the hook around even with optimizations applied
-        const fn crucible_cast_hook<T, const N: usize>(ptr: *const T, _new_len: usize) -> *const [T; N] {
-            ptr.cast()
-        }
-
-        let new_ptr = crucible_cast_hook::<T, N>(self.as_ptr(), new_len);
-
         // SAFETY: We cast a slice of `new_len * N` elements into
         // a slice of `new_len` many `N` elements chunks.
-        unsafe { from_raw_parts(new_ptr, new_len) }
+        unsafe { from_raw_parts(self.as_ptr().cast(), new_len) }
     }
 
     /// Splits the slice into a slice of `N`-element arrays,
@@ -1525,19 +1503,9 @@ impl<T> [T] {
         );
         // SAFETY: Caller must guarantee that `N` is nonzero and exactly divides the slice length
         let new_len = unsafe { exact_div(self.len(), N) };
-
-        /// Given a pointer to the first of `new_len * N` elements, view the elements as `new_len`
-        /// arrays of `N` elements each, and return a pointer to the first of the arrays.
-        #[inline(never)] // Keep the hook around even with optimizations applied
-        const fn crucible_cast_hook<T, const N: usize>(ptr: *mut T, _new_len: usize) -> *mut [T; N] {
-            ptr.cast()
-        }
-
-        let new_ptr = crucible_cast_hook::<T, N>(self.as_mut_ptr(), new_len);
-
         // SAFETY: We cast a slice of `new_len * N` elements into
         // a slice of `new_len` many `N` elements chunks.
-        unsafe { from_raw_parts_mut(new_ptr, new_len) }
+        unsafe { from_raw_parts_mut(self.as_mut_ptr().cast(), new_len) }
     }
 
     /// Splits the slice into a slice of `N`-element arrays,

--- a/libs/crucible/alloc.rs
+++ b/libs/crucible/alloc.rs
@@ -52,10 +52,7 @@ unsafe impl<T> alloc::Allocator for TypedAllocator<T> {
         unsafe {
             let len = size_to_len::<T>(layout.size());
             let ptr = NonNull::new_unchecked(allocate::<T>(len));
-            Ok(NonNull::slice_from_raw_parts(
-                core::mem::transmute::<NonNull<T>, NonNull<u8>>(ptr),
-                len,
-            ))
+            Ok(NonNull::slice_from_raw_parts(ptr.cast::<u8>(), len))
         }
     }
     unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {
@@ -70,10 +67,7 @@ unsafe impl<T> alloc::Allocator for TypedAllocator<T> {
         unsafe {
             let len = size_to_len::<T>(layout.size());
             let ptr = NonNull::new_unchecked(allocate_zeroed::<T>(len));
-            Ok(NonNull::slice_from_raw_parts(
-                core::mem::transmute::<NonNull<T>, NonNull<u8>>(ptr),
-                len,
-            ))
+            Ok(NonNull::slice_from_raw_parts(ptr.cast::<u8>(), len))
         }
     }
     unsafe fn grow(

--- a/libs/std/src/sync/mod.rs
+++ b/libs/std/src/sync/mod.rs
@@ -180,8 +180,6 @@ pub use core::sync::atomic;
 pub use alloc_crate::sync::UniqueArc;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use alloc_crate::sync::{Arc, Weak};
-#[stable(feature = "rc_raw", since = "1.17.0")]
-pub use alloc_crate::sync::ArcInner;
 
 #[unstable(feature = "mpmc_channel", issue = "126840")]
 pub mod mpmc;

--- a/libs/std/src/thread/thread.rs
+++ b/libs/std/src/thread/thread.rs
@@ -3,7 +3,7 @@ use super::main_thread;
 use crate::ffi::CStr;
 use crate::fmt;
 use crate::pin::Pin;
-use crate::sync::{Arc, ArcInner};
+use crate::sync::Arc;
 use crate::sys::sync::Parker;
 use crate::time::Duration;
 
@@ -279,7 +279,7 @@ impl Thread {
     pub fn into_raw(self) -> *const () {
         // Safety: We only expose an opaque pointer, which maintains the `Pin` invariant.
         let inner = unsafe { Pin::into_inner_unchecked(self.inner) };
-        Arc::into_inner_raw(inner) as *const ()
+        Arc::into_raw_with_allocator(inner).0 as *const ()
     }
 
     /// Constructs a `Thread` from a raw pointer.
@@ -302,7 +302,7 @@ impl Thread {
     pub unsafe fn from_raw(ptr: *const ()) -> Thread {
         // Safety: Upheld by caller.
         unsafe {
-            Thread { inner: Pin::new_unchecked(Arc::from_inner_raw(ptr as *const ArcInner<Inner>)) }
+            Thread { inner: Pin::new_unchecked(Arc::from_raw(ptr as *const Inner)) }
         }
     }
 


### PR DESCRIPTION
Now that `MirAggregate` flattening has landed, many of `mir-jsons`'s standard library patches are no longer necessary, as `crucible-mir` can now simulate many more pointer casts than it could before. This PR removes as many as possible.

Two patches which I considered removing (but ultimately abstained) are:

* https://github.com/GaloisInc/mir-json/pull/277/changes/9a13561525ec45637c0fa3b6a7a2c9cffaba7b30 (`libs: use hook in core::array::from_ref`)
* https://github.com/GaloisInc/mir-json/pull/277/changes/fee07c8755b28bfbe7152384ea076d7559d90320 (`libs: use hooks in core::slice::from_ref/mut`)

These functions use pointer casts from `*const T` to `*const [T; 1]`, and some testing suggests that `crucible-mir` doesn't support these types of casts just yet. (Should it?) 

Fixes #293.