### PR TITLE
Use architecture-generic `memchr` implementations

### DIFF
--- a/libs/Patches.md
+++ b/libs/Patches.md
@@ -318,6 +318,13 @@ into the main commit for that patch, and then the *Update* line can be removed.
   too high-level to model this. We remove the optimization in favor of a slower
   (but still correct) implementation.
 
+* Use architecture-generic `memchr` implementations (last applied: August 18, 2026)
+
+  The `memchr` crate uses inline assembly that is specialized for particular
+  architectures (e.g., x86-64 and AArch64), which `crucible-mir` does not
+  support. We instead fall back to a generic `memchr` implementation that works
+  on all architectures.
+
 # Notes
 
 This section contains more detailed notes about why certain patches are written

--- a/libs/memchr/src/memchr.rs
+++ b/libs/memchr/src/memchr.rs
@@ -506,30 +506,7 @@ unsafe fn memchr_raw(
     start: *const u8,
     end: *const u8,
 ) -> Option<*const u8> {
-    #[cfg(target_arch = "x86_64")]
-    {
-        // x86_64 does CPU feature detection at runtime in order to use AVX2
-        // instructions even when the `avx2` feature isn't enabled at compile
-        // time. This function also handles using a fallback if neither AVX2
-        // nor SSE2 (unusual) are available.
-        crate::arch::x86_64::memchr::memchr_raw(needle, start, end)
-    }
-    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
-    {
-        crate::arch::wasm32::memchr::memchr_raw(needle, start, end)
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        crate::arch::aarch64::memchr::memchr_raw(needle, start, end)
-    }
-    #[cfg(not(any(
-        target_arch = "x86_64",
-        all(target_arch = "wasm32", target_feature = "simd128"),
-        target_arch = "aarch64"
-    )))]
-    {
-        crate::arch::all::memchr::One::new(needle).find_raw(start, end)
-    }
+    crate::arch::all::memchr::One::new(needle).find_raw(start, end)
 }
 
 /// memrchr, but using raw pointers to represent the haystack.
@@ -543,26 +520,7 @@ unsafe fn memrchr_raw(
     start: *const u8,
     end: *const u8,
 ) -> Option<*const u8> {
-    #[cfg(target_arch = "x86_64")]
-    {
-        crate::arch::x86_64::memchr::memrchr_raw(needle, start, end)
-    }
-    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
-    {
-        crate::arch::wasm32::memchr::memrchr_raw(needle, start, end)
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        crate::arch::aarch64::memchr::memrchr_raw(needle, start, end)
-    }
-    #[cfg(not(any(
-        target_arch = "x86_64",
-        all(target_arch = "wasm32", target_feature = "simd128"),
-        target_arch = "aarch64"
-    )))]
-    {
-        crate::arch::all::memchr::One::new(needle).rfind_raw(start, end)
-    }
+    crate::arch::all::memchr::One::new(needle).rfind_raw(start, end)
 }
 
 /// memchr2, but using raw pointers to represent the haystack.
@@ -577,27 +535,8 @@ unsafe fn memchr2_raw(
     start: *const u8,
     end: *const u8,
 ) -> Option<*const u8> {
-    #[cfg(target_arch = "x86_64")]
-    {
-        crate::arch::x86_64::memchr::memchr2_raw(needle1, needle2, start, end)
-    }
-    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
-    {
-        crate::arch::wasm32::memchr::memchr2_raw(needle1, needle2, start, end)
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        crate::arch::aarch64::memchr::memchr2_raw(needle1, needle2, start, end)
-    }
-    #[cfg(not(any(
-        target_arch = "x86_64",
-        all(target_arch = "wasm32", target_feature = "simd128"),
-        target_arch = "aarch64"
-    )))]
-    {
-        crate::arch::all::memchr::Two::new(needle1, needle2)
-            .find_raw(start, end)
-    }
+    crate::arch::all::memchr::Two::new(needle1, needle2)
+        .find_raw(start, end)
 }
 
 /// memrchr2, but using raw pointers to represent the haystack.
@@ -612,29 +551,8 @@ unsafe fn memrchr2_raw(
     start: *const u8,
     end: *const u8,
 ) -> Option<*const u8> {
-    #[cfg(target_arch = "x86_64")]
-    {
-        crate::arch::x86_64::memchr::memrchr2_raw(needle1, needle2, start, end)
-    }
-    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
-    {
-        crate::arch::wasm32::memchr::memrchr2_raw(needle1, needle2, start, end)
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        crate::arch::aarch64::memchr::memrchr2_raw(
-            needle1, needle2, start, end,
-        )
-    }
-    #[cfg(not(any(
-        target_arch = "x86_64",
-        all(target_arch = "wasm32", target_feature = "simd128"),
-        target_arch = "aarch64"
-    )))]
-    {
-        crate::arch::all::memchr::Two::new(needle1, needle2)
-            .rfind_raw(start, end)
-    }
+    crate::arch::all::memchr::Two::new(needle1, needle2)
+        .rfind_raw(start, end)
 }
 
 /// memchr3, but using raw pointers to represent the haystack.
@@ -650,33 +568,8 @@ unsafe fn memchr3_raw(
     start: *const u8,
     end: *const u8,
 ) -> Option<*const u8> {
-    #[cfg(target_arch = "x86_64")]
-    {
-        crate::arch::x86_64::memchr::memchr3_raw(
-            needle1, needle2, needle3, start, end,
-        )
-    }
-    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
-    {
-        crate::arch::wasm32::memchr::memchr3_raw(
-            needle1, needle2, needle3, start, end,
-        )
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        crate::arch::aarch64::memchr::memchr3_raw(
-            needle1, needle2, needle3, start, end,
-        )
-    }
-    #[cfg(not(any(
-        target_arch = "x86_64",
-        all(target_arch = "wasm32", target_feature = "simd128"),
-        target_arch = "aarch64"
-    )))]
-    {
-        crate::arch::all::memchr::Three::new(needle1, needle2, needle3)
-            .find_raw(start, end)
-    }
+    crate::arch::all::memchr::Three::new(needle1, needle2, needle3)
+        .find_raw(start, end)
 }
 
 /// memrchr3, but using raw pointers to represent the haystack.
@@ -692,33 +585,8 @@ unsafe fn memrchr3_raw(
     start: *const u8,
     end: *const u8,
 ) -> Option<*const u8> {
-    #[cfg(target_arch = "x86_64")]
-    {
-        crate::arch::x86_64::memchr::memrchr3_raw(
-            needle1, needle2, needle3, start, end,
-        )
-    }
-    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
-    {
-        crate::arch::wasm32::memchr::memrchr3_raw(
-            needle1, needle2, needle3, start, end,
-        )
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        crate::arch::aarch64::memchr::memrchr3_raw(
-            needle1, needle2, needle3, start, end,
-        )
-    }
-    #[cfg(not(any(
-        target_arch = "x86_64",
-        all(target_arch = "wasm32", target_feature = "simd128"),
-        target_arch = "aarch64"
-    )))]
-    {
-        crate::arch::all::memchr::Three::new(needle1, needle2, needle3)
-            .rfind_raw(start, end)
-    }
+    crate::arch::all::memchr::Three::new(needle1, needle2, needle3)
+        .rfind_raw(start, end)
 }
 
 /// Count all matching bytes, but using raw pointers to represent the haystack.
@@ -728,26 +596,7 @@ unsafe fn memrchr3_raw(
 /// Pointers must be valid. See `One::count_raw`.
 #[inline]
 unsafe fn count_raw(needle: u8, start: *const u8, end: *const u8) -> usize {
-    #[cfg(target_arch = "x86_64")]
-    {
-        crate::arch::x86_64::memchr::count_raw(needle, start, end)
-    }
-    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
-    {
-        crate::arch::wasm32::memchr::count_raw(needle, start, end)
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        crate::arch::aarch64::memchr::count_raw(needle, start, end)
-    }
-    #[cfg(not(any(
-        target_arch = "x86_64",
-        all(target_arch = "wasm32", target_feature = "simd128"),
-        target_arch = "aarch64"
-    )))]
-    {
-        crate::arch::all::memchr::One::new(needle).count_raw(start, end)
-    }
+    crate::arch::all::memchr::One::new(needle).count_raw(start, end)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This addresses one half of #311 by switching to less optimized code that `crucible-mir` has a fighting chance of simulating.

Note that in order to simulate the architecture-generic code that this falls back to, `crucible-mir` also needs to be able to simulate raw pointer comparisons between pointers derived from the same allocation. This is something that `crucible-mir` does not yet know how to do, but we will add this capability to `crucible-mir` separately as part of the second half of a fix for issue #311.