### PR TITLE
Do more validation on values (e.g., valid bool, valid char)

### DIFF
--- a/doc/mir-json-schema.ts
+++ b/doc/mir-json-schema.ts
@@ -294,7 +294,7 @@ type ConstVal =
   | { kind: "coroutine_closure", upvars: ConstVal[] }
   | { kind: "fn_ptr", "def_id": DefId }
   | { kind: "trait_object", def_id: DefId, trait_id: DefId, vtable: DefId }
-  | { kind: "unsupported" }
+  | { kind: "unsupported", debug_val: string }
 
 
 

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -1499,8 +1499,8 @@ pub fn try_render_opty<'tcx>(
             })
         }
 
-        ty::TyKind::Coroutine(_, _) => return Err(RenderErr::Unsupported), // not supported in haskell
-        ty::TyKind::CoroutineWitness(_, _) => return Err(RenderErr::Unsupported), // not supported in haskell
+        ty::TyKind::Coroutine(_, _) => return Err(RenderErr::Unsupported),
+        ty::TyKind::CoroutineWitness(_, _) => return Err(RenderErr::Unsupported),
 
         ty::TyKind::Tuple(elts) => {
             let mut vals = Vec::with_capacity(elts.len());

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -1236,25 +1236,28 @@ pub fn render_opty<'tcx>(
     icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
     op_ty: &interpret::OpTy<'tcx>,
 ) -> serde_json::Value {
-    try_render_opty(mir, icx, op_ty).unwrap_or_else(|err| {
-        match err {
-            RenderErr::Mismatch => panic!("Unexpexpected type mismatch"),
-            RenderErr::Unsupported =>
-                json!({
-                    "kind": "unsupported",
-                    "debug_val": format!("{:?}", op_ty),
-                })
-        }
+    try_render_opty(mir, icx, op_ty).unwrap_or_else(|_err| {
+        // We report "unsupported" even when we encounter "mismatch".  The reason
+        // is that the constraints on what can be stored in unions in Rust
+        // is pretty lax at the moment, but we actually look for well-formed
+        // values in the union alternatives.  So if we encounter one of the
+        // unusual union values (e.g., half one side of the union, half the
+        // other, which apparently is fine in stable Rust at the moment),
+        // we may get a mismatch.
+        json!({
+            "kind": "unsupported",
+            "debug_val": format!("{:?}", op_ty),
+        })
     })
 }
 
 
 /// Errors that may occur while interpreting bytes as a value of a specific type
 pub enum RenderErr {
-    /// Indicates that the bytes do not match the given type
+    /// Indicates that the bytes do not match the given type.
     Mismatch,
 
-    /// Indicates that we encountered a type that we don't know how to process
+    /// Indicates that we encountered a type that we don't know how to process.
     Unsupported
 }
 
@@ -1273,6 +1276,14 @@ fn alloc_from_prov<'tcx>(tcx: TyCtxt<'tcx>, mb_prov: Option<interpret::CtfeProve
     tcx.try_get_global_alloc(prov.alloc_id()).ok_or(RenderErr::Mismatch)
 }
 
+fn scalar_const<T: ToString>(tag: &str, size: Size, bits: T) -> serde_json::Value {
+    json!({
+        "kind": tag.to_string(),
+        "size": size.bytes(),
+        "val": bits.to_string(),
+    })
+}
+
 pub fn try_render_opty<'tcx>(
     mir: &mut MirState<'_, 'tcx>,
     icx: &mut interpret::InterpCx<'tcx, RenderConstMachine<'tcx>>,
@@ -1283,27 +1294,31 @@ pub fn try_render_opty<'tcx>(
     let tcx = mir.tcx;
 
     Ok(match *ty.kind() {
-        ty::TyKind::Bool |
-        ty::TyKind::Char |
-        ty::TyKind::Uint(_) =>
+        ty::TyKind::Bool => {
+            let s = check_mismatch(icx.read_immediate(op_ty))?.to_scalar();
+            let size = layout.size();
+            let bits = s.to_bits(size).unwrap();
+            if !(bits == 0 || bits == 1) { return Err(RenderErr::Mismatch) }
+            scalar_const("bool", size, bits)
+        },
+        ty::TyKind::Char => {
+            let s = check_mismatch(icx.read_immediate(op_ty))?.to_scalar();
+            let size = layout.size();
+            let bits = s.to_u32().unwrap();
+            char::from_u32(bits).ok_or(RenderErr::Mismatch)?;
+            scalar_const("char", size, bits)
+        },
+        ty::TyKind::Uint(k) =>
         {
             let s = check_mismatch(icx.read_immediate(op_ty))?.to_scalar();
             let size = layout.size();
             let bits = s.to_bits(size).unwrap();
-
-            json!({
-                "kind": match *ty.kind() {
-                    ty::TyKind::Bool => "bool",
-                    ty::TyKind::Char => "char",
-                    ty::TyKind::Uint(ty::UintTy::Usize) => "usize",
-                    ty::TyKind::Uint(_) => "uint",
-                    _ => unreachable!(),
-                },
-                "size": size.bytes(),
-                "val": bits.to_string(),
-            })
+            match k {
+                ty::UintTy::Usize => scalar_const("usize",size,bits),
+                _                 => scalar_const("uint", size,bits)
+            }
         }
-        ty::TyKind::Int(_i) => {
+        ty::TyKind::Int(k) => {
             let s = check_mismatch(icx.read_immediate(op_ty))?.to_scalar();
             let size = layout.size();
             let bits = s.to_bits(size).unwrap();
@@ -1312,32 +1327,20 @@ pub fn try_render_opty<'tcx>(
                 // Sign-extend to 128 bits
                 val |= -1_i128 << size.bits();
             }
-
-            json!({
-                "kind": match *ty.kind() {
-                    ty::TyKind::Int(ty::IntTy::Isize) => "isize",
-                    ty::TyKind::Int(_) => "int",
-                    _ => unreachable!(),
-                },
-                "size": size.bytes(),
-                "val": val.to_string(),
-            })
+            match k {
+                ty::IntTy::Isize => scalar_const("isize", size, val),
+                _ => scalar_const("int", size, val)
+            }
         }
         ty::TyKind::Float(fty) => {
             let s = check_mismatch(icx.read_immediate(op_ty))?.to_scalar();
             let size = layout.size();
-            let val_str = match fty {
-                ty::FloatTy::F16 => s.to_f16().unwrap().to_string(),
-                ty::FloatTy::F32 => s.to_f32().unwrap().to_string(),
-                ty::FloatTy::F64 => s.to_f64().unwrap().to_string(),
-                ty::FloatTy::F128 => s.to_f128().unwrap().to_string(),
-            };
-
-            json!({
-                "kind": "float",
-                "size": size.bytes(),
-                "val": val_str,
-            })
+            match fty {
+                ty::FloatTy::F16  => scalar_const("float", size, s.to_f16().unwrap()),
+                ty::FloatTy::F32  => scalar_const("float", size, s.to_f32().unwrap()),
+                ty::FloatTy::F64  => scalar_const("float", size, s.to_f64().unwrap()),
+                ty::FloatTy::F128 => scalar_const("float", size, s.to_f128().unwrap()),
+            }
         }
         ty::TyKind::Adt(adt_def, _args) => match adt_def.adt_kind() {
             ty::AdtKind::Struct => {
@@ -1412,8 +1415,10 @@ pub fn try_render_opty<'tcx>(
             },
         },
 
-        ty::TyKind::Foreign(_) => todo!("foreign is unimplemented"), // can't do this
+        ty::TyKind::Foreign(_) => return Err(RenderErr::Unsupported), // can't do this
+        
         ty::TyKind::Str => unreachable!("str type should not occur here"),
+
         ty::TyKind::Array(ety, sz) => {
             let sz = get_const_usize(tcx, sz);
             let mut vals = Vec::with_capacity(sz);
@@ -1468,7 +1473,9 @@ pub fn try_render_opty<'tcx>(
                         "def_id": inst_id_str(tcx, instance),
                     })
                 },
-                _ => unreachable!("Function pointer doesn't point to a function"),
+
+                // Function pointer doesn't point to a function
+                _ => return Err(RenderErr::Unsupported) 
             }
         }
         ty::TyKind::Dynamic(_, _) => unreachable!("dynamic should not occur here"),
@@ -1489,8 +1496,9 @@ pub fn try_render_opty<'tcx>(
                 "upvars": upvar_vals,
             })
         }
-        ty::TyKind::Coroutine(_, _) => todo!("coroutine not supported yet"), // not supported in haskell
-        ty::TyKind::CoroutineWitness(_, _) => todo!("coroutinewitness not supported yet"), // not supported in haskell
+
+        ty::TyKind::Coroutine(_, _) => return Err(RenderErr::Unsupported), // not supported in haskell
+        ty::TyKind::CoroutineWitness(_, _) => return Err(RenderErr::Unsupported), // not supported in haskell
 
         ty::TyKind::Tuple(elts) => {
             let mut vals = Vec::with_capacity(elts.len());
@@ -1739,8 +1747,9 @@ fn try_render_ref_opty<'tcx>(
             return raw_ptr(offset);
         }
         _ =>
-            // Give up
-            return Err(RenderErr::Unsupported)
+            // Give up.  We return a Mismatch, because we exepected a data
+            // pointer but we got a function or vtable one.
+            return Err(RenderErr::Mismatch)
     };
 
     // TODO(#241): Lift this restriction.
@@ -1795,9 +1804,7 @@ fn try_render_ref_opty<'tcx>(
                         // the trait bounds are auto traits. We do not
                         // currently support computing vtables for these sorts
                         // of trait objects (see #239).
-                        return Ok(json!({
-                            "kind": "unsupported",
-                        }))
+                        return Err(RenderErr::Unsupported)
                 }
             },
             _ => (),

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -1244,6 +1244,7 @@ pub fn render_opty<'tcx>(
         // unusual union values (e.g., half one side of the union, half the
         // other, which apparently is fine in stable Rust at the moment),
         // we may get a mismatch.
+        // For example, see `Mix/Z0` in `tests/regression/test_statics/test.rs`.
         json!({
             "kind": "unsupported",
             "debug_val": format!("{:?}", op_ty),
@@ -1296,16 +1297,16 @@ pub fn try_render_opty<'tcx>(
     Ok(match *ty.kind() {
         ty::TyKind::Bool => {
             let s = check_mismatch(icx.read_immediate(op_ty))?.to_scalar();
+            check_mismatch(s.to_bool())?;
             let size = layout.size();
             let bits = s.to_bits(size).unwrap();
-            if !(bits == 0 || bits == 1) { return Err(RenderErr::Mismatch) }
             scalar_const("bool", size, bits)
         },
         ty::TyKind::Char => {
             let s = check_mismatch(icx.read_immediate(op_ty))?.to_scalar();
+            check_mismatch(s.to_char())?;
             let size = layout.size();
-            let bits = s.to_u32().unwrap();
-            char::from_u32(bits).ok_or(RenderErr::Mismatch)?;
+            let bits = s.to_bits(size).unwrap();
             scalar_const("char", size, bits)
         },
         ty::TyKind::Uint(k) =>

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -1748,7 +1748,7 @@ fn try_render_ref_opty<'tcx>(
             return raw_ptr(offset);
         }
         _ =>
-            // Give up.  We return a Mismatch, because we exepected a data
+            // Give up.  We return a Mismatch, because we expected a data
             // pointer but we got a function or vtable one.
             return Err(RenderErr::Mismatch)
     };

--- a/src/analyz/ty_json.rs
+++ b/src/analyz/ty_json.rs
@@ -1415,7 +1415,8 @@ pub fn try_render_opty<'tcx>(
             },
         },
 
-        ty::TyKind::Foreign(_) => return Err(RenderErr::Unsupported), // can't do this
+        // `Foreign` probably can't occur here, since it's unsized
+        ty::TyKind::Foreign(_) => return Err(RenderErr::Unsupported),
         
         ty::TyKind::Str => unreachable!("str type should not occur here"),
 

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -47,7 +47,7 @@ expect_static_matches() {
   actual=$(jq --arg n "$suffix" \
     '.statics[]
        | select(.name | endswith($n))
-       | del(.name, .ty, .rendered.def_id, .rendered.element_ty)' \
+       | del(.name, .ty, .rendered.def_id, .rendered.element_ty, .rendered.debug_val)' \
     "$file")
 
   if [[ -z "$actual" ]]; then

--- a/tests/regression/test_statics/test.rs
+++ b/tests/regression/test_statics/test.rs
@@ -75,7 +75,7 @@ pub union U { cast: fn(u32) -> u32 }
 
 // We can use a union to circumvent value expectations:
 // here's how we can make a function pointer, which has the value 8.
-// Without the union `rust` reports "undefined behavior".
+// Without the union `rustc` reports "undefined behavior".
 pub static Z3: U = {
     U { cast: unsafe { core::mem::transmute((&8u8) as *const u8) } }
 };

--- a/tests/regression/test_statics/test.rs
+++ b/tests/regression/test_statics/test.rs
@@ -51,7 +51,7 @@ pub union Mix {
 // Z0 has a value which is half from one of the union and half from the other
 pub static Z0: Mix = {
     let mut u = Mix { f1: (true, 99) };
-    u.f2.0 = 99; // overwrite through *the other* union, but only half the value
+    u.f2.0 = 99; // overwrite through *the other* union variant, but only half the value
     u
 };
 

--- a/tests/regression/test_statics/test.rs
+++ b/tests/regression/test_statics/test.rs
@@ -43,8 +43,50 @@ pub static mut MUT_ARR: [u32; 3] = [1, 2, 3];
 fn fn_ptr_target() -> u32 { 100 }
 pub static FN_PTR: fn() -> u32 = fn_ptr_target;
 
+pub union Mix {
+  f1: (bool, u8),
+  f2: (u8, bool),
+}
+
+// Z0 has a value which is half from one of the union and half from the other
+pub static Z0: Mix = {
+    let mut u = Mix { f1: (true, 99) };
+    u.f2.0 = 99; // overwrite through *the other* union, but only half the value
+    u
+};
+
+// Some function, so we can initialize function pointers.
+fn f(arg: i32) -> i32 { arg }
+
+// `Z1` points to `f`
+pub static Z1: fn(i32) -> i32 = f;
+
+pub struct T(*const());
+unsafe impl Sync for T {}
+
+// `Z2` is a const*() pointer that points to a function
+pub static Z2: T = {
+   let f1 = f as fn(i32) -> i32;
+   T(unsafe { core::mem::transmute(f1) })
+};
+
+
+pub union U { cast: fn(u32) -> u32 }
+
+// We can use a union to circumvent value expectations:
+// here's how we can make a function pointer, which has the value 8.
+// Without the union `rust` reports "undefined behavior".
+pub static Z3: U = {
+    U { cast: unsafe { core::mem::transmute((&8u8) as *const u8) } }
+};
+
 // Force each static to be used so it appears in mono items.
 pub fn touch_all() -> u32 {
+    let _a       = &Z0;
+    let _a       = &Z1;
+    let T(_a)    = Z2;
+    let _a       = unsafe { Z3.cast };
+
     let mut_val = unsafe { MUT_STATIC };
     let mut_arr_val = unsafe { MUT_ARR[0] };
     ORDINARY

--- a/tests/regression/test_statics/test.rs
+++ b/tests/regression/test_statics/test.rs
@@ -64,7 +64,7 @@ pub static Z1: fn(i32) -> i32 = f;
 pub struct T(*const());
 unsafe impl Sync for T {}
 
-// `Z2` is a const*() pointer that points to a function
+// `Z2` is a *const() pointer that points to a function
 pub static Z2: T = {
    let f1 = f as fn(i32) -> i32;
    T(unsafe { core::mem::transmute(f1) })

--- a/tests/regression/test_statics/test.sh
+++ b/tests/regression/test_statics/test.sh
@@ -89,3 +89,36 @@ expect_static_matches "::FN_PTR" '{
 expect_json_contains \
   '.fns[] | select(.name | test("::fn_ptr_target$"))' \
   test.linked-mir.json
+
+# Union with a mixed payload: no variant covers the whole value.
+expect_static_matches "::Z0" '{
+  "kind": "constant",
+  "mutable": false,
+  "rendered": { "kind": "unsupported" }
+}'
+
+# Function pointer with a non-trivial signature.
+expect_static_matches "::Z1" '{
+  "kind": "constant",
+  "mutable": false,
+  "rendered": { "kind": "fn_ptr" }
+}'
+
+# `*const ()` field holding a transmuted function pointer.
+expect_static_matches "::Z2" '{
+  "kind": "constant",
+  "mutable": false,
+  "rendered": { "kind": "unsupported" }
+}'
+
+# Union used to inject an arbitrary bit pattern into a fn-pointer slot.
+expect_static_matches "::Z3" '{
+  "kind": "constant",
+  "mutable": false,
+  "rendered": { "kind": "unsupported" }
+}'
+
+# The callee referenced by Z1/Z2 must appear in `fns`.
+expect_json_contains \
+  '.fns[] | select(.name | test("::f$"))' \
+  test.linked-mir.json


### PR DESCRIPTION
Also, we update some more of the error behaviors---turn things into explicit "unsupported", and don't panic at the top level if we find a mismatch, but just report unsupported.

Fixes #314